### PR TITLE
Add `clang` and `clang++` as the default `CC` and `CXX` when targeting macOS

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -30,5 +30,11 @@ function target_envs(target::AbstractString)
         "CC_FOR_BUILD" => "/usr/bin/gcc",
     )
 
+    # If we're on OSX, default to clang instead of gcc for CC and CXX
+    if contains(target, "-apple-")
+        mapping["CC"] = "/opt/$(target)/bin/clang"
+        mapping["CXX"] = "/opt/$(target)/bin/clang++"
+    end
+
     return mapping
 end

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -1,6 +1,6 @@
 const rootfs_url_root = "https://julialangmirror.s3.amazonaws.com"
-const rootfs_url = "$rootfs_url_root/binarybuilder-rootfs-2017-11-10.tar.gz"
-const rootfs_sha256 = "81a233118b0e456eecd568483571796cc78ebab5fa8585b8d218d81449a68dee"
+const rootfs_url = "$rootfs_url_root/binarybuilder-rootfs-2017-11-19.tar.gz"
+const rootfs_sha256 = "87cd567fd7c94ca040a69ba487256b002f2edc5d8d5d8799956ff6cdbcf86b3f"
 const sandbox_path = joinpath(dirname(@__FILE__), "..", "deps", "sandbox")
 
 # Note that rootfs_tar and rootfs can be overridden by the environment variables shown in __init__()


### PR DESCRIPTION
This bumps up to a new rootfs that incorporates https://github.com/staticfloat/julia-docker/commit/7304d4b9772d40a1094b14401e2db0ad54897db2.  This defaults `CC` and `CXX` to `clang` and `clang++`, respectively, but it still has `gcc` and friends available if someone really wants to use those.  I have confirmed that compiling a "Hello World" with `clang++` creates code that successfully links against `libc++` and can run on an actual mac machine.