### PR TITLE
Remove sleep on assertion fail

### DIFF
--- a/deps/sandbox.c
+++ b/deps/sandbox.c
@@ -40,7 +40,6 @@
 static void _check(int ok, int line) {
   if (!ok) {
     printf("At line %d, ABORTED (%s)!\n", line, strerror(errno));
-    sleep(1000);
     abort();
   }
 }


### PR DESCRIPTION
Not sure why that was there, I'm sure I had a reason at some point. Oh well, this was causing travis timeouts rather than failures.