### PR TITLE
Fix "no method matching start(::Void)" with QemuRunner

### DIFF
--- a/src/QemuRunner.jl
+++ b/src/QemuRunner.jl
@@ -57,6 +57,8 @@ function platform_def_9p_mappings(platform)
         sdk_shard_path = joinpath(shards_cache, sdk_version)
         push!(mapping, sdk_shard_path => joinpath("/opt", tp, sdk_version))
     end
+    
+    return mapping
 end
 
 platform_accelerator() = Compat.Sys.islinux() ? "kvm" : "hvf"


### PR DESCRIPTION
The `mapping` keyword was initialized to nothing; it seems like it wasn't be returned by accident.