### PR TITLE
Fix @compat_gc_preserve on 0.7

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -38,7 +38,7 @@ end
 
 macro compat_gc_preserve(args...)
     if VERSION >= v"0.7-"
-        esc(Expr(:macrocall, Symbol("@gc_preserve"), args...))
+        esc(Expr(:macrocall, Expr(:., :Base, QuoteNode(Symbol("@gc_preserve"))), args...))
     else
         esc(args[end])
     end


### PR DESCRIPTION
This fixes the error I was getting previously:
```
ERROR: LoadError: LoadError: LoadError: LoadError: UndefVarError: @gc_preserve not defined
Stacktrace:
 [1] top-level scope
 [2] include at ./boot.jl:279 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:509
 [4] include at ./sysimg.jl:15 [inlined]
 [5] include(::String) at /Users/ericdavies/.julia/v0.7/BinaryBuilder/src/BinaryBuilder.jl:4
 [6] top-level scope
 [7] include at ./boot.jl:279 [inlined]
 [8] include_relative(::Module, ::String) at ./loading.jl:509
 [9] include at ./sysimg.jl:15 [inlined]
 [10] include(::String) at /Users/ericdavies/.julia/v0.7/BinaryBuilder/src/BinaryBuilder.jl:4
 [11] top-level scope
 [12] include at ./boot.jl:279 [inlined]
 [13] include_relative(::Module, ::String) at ./loading.jl:509
 [14] _require(::Symbol) at ./loading.jl:441
 [15] require(::Symbol) at ./loading.jl:300
in expression starting at <macrocall>:0
in expression starting at /Users/ericdavies/.julia/v0.7/BinaryBuilder/src/wizard/obtain_source.jl:47
in expression starting at /Users/ericdavies/.julia/v0.7/BinaryBuilder/src/Wizard.jl:15
in expression starting at /Users/ericdavies/.julia/v0.7/BinaryBuilder/src/BinaryBuilder.jl:16
```