### PR TITLE
Explicitly import `Libdl`

### DIFF
--- a/src/BinaryBuilder.jl
+++ b/src/BinaryBuilder.jl
@@ -4,6 +4,10 @@
 module BinaryBuilder
 using Compat
 using Reexport
+
+if VERSION >= v"0.7.0-DEV.3382"
+    import Libdl
+end
 @reexport using BinaryProvider
 
 include("Auditor.jl")


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/25459 moved `Libdl` to the
stdlib, which means that we need to explicitly import it now before we
can do things like `Libdl.dlopen()`.