### PR TITLE
Split out travis deploy as a separately-callable function

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,5 +8,5 @@ MbedTLS
 GitHub
 PkgDev
 JSON
-HTTP
+HTTP 0.6.0
 ProgressMeter

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -166,9 +166,9 @@ function authenticate_travis(github_token)
     JSON.parse(resp.body)["access_token"]
 end
 
-function sync_and_wait_travis(state, repo_name, travis_token)
-    println(state.outs, "Asking travis to sync github and waiting until it knows about our new repo.")
-    println(state.outs, "This may take a few seconds (or minutes, depending on Travis' mood)")
+function sync_and_wait_travis(outs, repo_name, travis_token)
+    println(outs, "Asking travis to sync github and waiting until it knows about our new repo.")
+    println(outs, "This may take a few seconds (or minutes, depending on Travis' mood)")
     headers = merge!(Dict("Authorization"=>"token $travis_token"),travis_headers)
     resp = HTTP.post("https://api.travis-ci.org/users/sync"; headers=headers, statusraise=false)
     if resp.status != 200 && resp.status != 409
@@ -186,16 +186,16 @@ function sync_and_wait_travis(state, repo_name, travis_token)
     end
 end
 
-function activate_travis_repo(state, repo_id, travis_token)
+function activate_travis_repo(repo_id, travis_token)
     headers = merge!(Dict("Authorization"=>"token $travis_token",
                           "Travis-API-Version"=>3))
     HTTP.post("https://api.travis-ci.org/repo/$(repo_id)/activate"; headers=headers)
 end
 
-function obtain_token(state, repo_name, user)
-    println(state.outs)
+function obtain_token(outs, ins, repo_name, user)
+    println(outs)
     print_with_color(:bold, "Creating a github access token.\n")
-    println(state.outs, """
+    println(outs, """
     We will use this token to create to repository, and then pass it to travis
     for future uploads of binary artifacts.
     You will be prompted for your GitHub credentials.
@@ -211,25 +211,25 @@ function obtain_token(state, repo_name, user)
         "fingerpint" => randstring(40)
     )
     while true
-        print(state.outs, "Please enter the github.com password for $(user): ")
-        terminal = Base.Terminals.TTYTerminal("xterm", state.ins, state.outs, state.outs)
-        old = set_terminal_echo(Base._fd(state.ins), false)
+        print(outs, "Please enter the github.com password for $(user): ")
+        terminal = Base.Terminals.TTYTerminal("xterm", ins, outs, outs)
+        old = set_terminal_echo(Base._fd(ins), false)
         pass = try
-            readline(state.ins)
+            readline(ins)
         finally
-            set_terminal_echo(Base._fd(state.ins), old)
+            set_terminal_echo(Base._fd(ins), old)
         end
-        println(state.outs)
+        println(outs)
         resp = HTTP.post("https://$user:$pass@api.github.com/authorizations"; body=JSON.json(params), statusraise=false)
         if resp.status == 401 && startswith(strip(get(resp.headers, "X-Github-Otp", "")), "required")
-            println(state.outs, "Two factor authentication in use.  Enter auth code.")
-            print(state.outs, "> ")
-            otp_code = readline(state.ins)
+            println(outs, "Two factor authentication in use.  Enter auth code.")
+            print(outs, "> ")
+            otp_code = readline(ins)
             resp = HTTP.post("https://$user:$pass@api.github.com/authorizations"; body=JSON.json(params), headers=Dict("X-GitHub-OTP"=>otp_code),
                 statusraise=false)
         end
         if resp.status == 401
-            print_with_color(:red, state.outs, "Invalid credentials!\n")
+            print_with_color(:red, outs, "Invalid credentials!\n")
             continue
         end
         if resp.status != 200
@@ -307,27 +307,61 @@ function local_deploy(state::WizardState)
     println("Your repository is all set up in $(repo_dir)")
 end
 
+function obtain_secure_key(outs, token, gr)
+    travis_token = authenticate_travis(token)
+    repo_id = sync_and_wait_travis(outs, GitHub.name(gr), travis_token)
+    activate_travis_repo(repo_id, travis_token)
+    # Obtain the appropriate encryption key from travis
+    key = JSON.parse(HTTP.get("https://api.travis-ci.org/repos/$(GitHub.name(gr))/key").body)["key"]
+    pk_ctx = MbedTLS.PKContext()
+    MbedTLS.parse_public_key!(pk_ctx, key)
+    # Encrypted the token
+    entropy = MbedTLS.Entropy()
+    rng = MbedTLS.CtrDrbg()
+    MbedTLS.seed!(rng, entropy)
+    outbuf = fill(UInt8(0), 4096)
+    len = MbedTLS.encrypt!(pk_ctx, token, outbuf, rng)
+    secure_key = base64encode(outbuf[1:len])
+end
+
+function get_github_user(outs, ins)
+    # Get user name
+    user = try
+        PkgDev.GitHub.user()
+    catch
+        print(outs, "GitHub user name: ")
+        readline(ins)
+    end
+    user
+end
+
+"""
+Sets up travis for an existing repository
+"""
+function setup_travis(repo)
+    # Get user name
+    user = get_github_user(STDOUT, STDIN)
+    gr = GitHub.Repo(repo)
+    token = obtain_token(STDOUT, STDIN, GitHub.name(gr), user)
+    secure_key = obtain_secure_key(STDOUT, token, gr)
+    print_travis_deploy(STDOUT, gr, secure_key)
+end
+
 function github_deploy(state::WizardState)
     println(state.outs, """
     Let's deploy a builder repository to GitHub. This repository will be set up
     to use Travis CI to build binaries and then upload them to GitHub releases.
     """)
 
-    # Get user name
-    user = try
-        PkgDev.GitHub.user()
-    catch
-        print(state.outs, "GitHub user name: ")
-        readline(state.ins)
-    end
-
     # Prompt for the GitHub repository name
     print(state.outs, "Enter the desired name for the new repository: ")
     github_name = readline(state.ins)
 
+    user = get_github_user(state.outs, state.ins)
+
     # Could re-use the package manager's token here, but we need to create a
     # new token for deployment purposes anyway
-    token = obtain_token(state, github_name, user)
+    token = obtain_token(state.outs, state.ins, github_name, user)
 
     # Create a local repository
     repo_dir = tempname()
@@ -361,20 +395,7 @@ function github_deploy(state::WizardState)
             refspecs=["+HEAD:refs/heads/master"])
         # Set up travis
         try
-            travis_token = authenticate_travis(token)
-            repo_id = sync_and_wait_travis(state, GitHub.name(gr), travis_token)
-            activate_travis_repo(state, repo_id, travis_token)
-            # Obtain the appropriate encryption key from travis
-            key = JSON.parse(HTTP.get("https://api.travis-ci.org/repos/$(GitHub.name(gr))/key").body)["key"]
-            pk_ctx = MbedTLS.PKContext()
-            MbedTLS.parse_public_key!(pk_ctx, key)
-            # Encrypted the token
-            entropy = MbedTLS.Entropy()
-            rng = MbedTLS.CtrDrbg()
-            MbedTLS.seed!(rng, entropy)
-            outbuf = fill(UInt8(0), 4096)
-            len = MbedTLS.encrypt!(pk_ctx, token, outbuf, rng)
-            secure_key = base64encode(outbuf[1:len])
+            secure_key = obtain_secure_key(state.outs, token, gr)
             open(joinpath(repo_dir, ".travis.yml"), "w") do f
                 # Create the first part of the .travis.yml file
                 print_travis_file(f, state)


### PR DESCRIPTION
Usage:
```
julia> BinaryBuilder.setup_travis("Keno/Rmath-julia")
GitHub user name: Keno

Creating a github access token.
We will use this token to create to repository, and then pass it to travis
for future uploads of binary artifacts.
You will be prompted for your GitHub credentials.

Please enter the github.com password for Keno:
Two factor authentication in use.  Enter auth code.
> 318501
Asking travis to sync github and waiting until it knows about our new repo.
This may take a few seconds (or minutes, depending on Travis' mood)
Done waiting
deploy:
    provider: releases
    api_key:
        # Note; this api_key is only valid for Keno/Rmath-julia; you need
        # to make your own: https://docs.travis-ci.com/user/deployment/releases/
        secure: HgZMI82Uup5x5cfmhK26mp6KbpHkRvGjnrGKghoGVfuY5ewwfM9UZ6ln0XxltjDP5cvCh4r3EpJNbYe9SjzF2ECnIn3xdJarNfXZME/CzXe4Lf0CA2WzXaUZT+NJKlH873y2n5rP5nPsUE0KP+5YoE3ZM5t80yc5uWlKaMdZl4R8YKkA2Lwzsy6YdvAVTB9vKEY9ETn6AySXc60dnZnd4LU+RjSJiTqjl3mhlFWoIfcC6rVFUKMwewsTk869+DArGjE5Y+fVZj848fqpmhaOYSx5cdwfOEeOLPFHgMJ8IQbbHXePPCezYH4BMVPvQBZ2ZC2B7zT7ySKz0OQIbD2L7LHrBf9KRBLCV3sSh8OC2LQGfE5yqvtLkxcD37qrfrep8Qus7rXw4pdmjFzVuRLq3jdLqtsLik3BID6s9Fteg5AsbvtcQHkIRhgttyDOcg7DD/Txm/Bz1Wn6HBJFEn/DZa+jQVH5ZqOTEhzO2rKrGoLbel61ivAfsMchn/wVjHzve03z5lh7M/To/hBGkrC1XpjI/MRCObypJ9zJWXtfZ2z21MihS1yuuf5Sgc1UGg4Xg9hfpVSvThPKpwS96478PMrd3AmmYZQUzBSVhYU3usdpPBKSb6aSxxbvTQNiDsJPVI4J8EzuY0xOgoTOfz1pE9hDlOQiF6O5mSmOylRaXDo=
    file_glob: true
    file: products/*
    skip_cleanup: true
    on:
        repo: Keno/Rmath-julia
        tags: true
```

cc @ChrisRackauckas

Fixes #118