### PR TITLE
Use rm instead of rmdir (because it exists)

### DIFF
--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -362,7 +362,7 @@ function step5_internal(state::WizardState, platform::Platform, message)
                             continue
                         end
                     elseif choice == 2
-                        rmdir(build_path; recursive = true)
+                        rm(build_path; force = true, recursive = true)
                         mkpath(build_path)
                         prefix, ur = setup_workspace(
                             build_path,


### PR DESCRIPTION
Stacktrace: https://www.dropbox.com/s/4hsozxml0gmvti5/Screenshot%202018-01-30%2016.54.38.png