### PR TITLE
Add a travis build step that tests sandbox changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,23 @@ env:
   matrix:
     - BINARYBUILDER_USE_SQUASHFS=true
     - BINARYBUILDER_USE_SQUASHFS=false
-
+    
 cache:
   directories:
     - deps/downloads
+
+# Add a test job that builds a new version of the sandbox.
+jobs:
+  include:
+    - stage: test
+      julia: 0.6
+      env:
+        - BINARYBUILDER_USE_SQUASHFS=false
+        - TEST_SANDBOX=true
+      
+
+before_script:
+   - if [ ${TEST_SANDBOX:-false} = true ]; then julia -e 'cd(Pkg.dir("BinaryBuilder","deps")); run(`gcc -o root/sandbox sandbox.c`)'; fi
 
 # Ironic.  He could provide binaries for others but not himself...
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,12 @@ jobs:
       env:
         - BINARYBUILDER_USE_SQUASHFS=false
         - TEST_SANDBOX=true
-      
 
-before_script:
+script:
+   - julia -e 'Pkg.clone(pwd())'
+   - julia -e 'Pkg.build("BinaryBuilder")'
    - if [ ${TEST_SANDBOX:-false} = true ]; then julia -e 'cd(Pkg.dir("BinaryBuilder","deps")); run(`gcc -o root/sandbox sandbox.c`)'; fi
+   - julia --check-bounds=yes -e 'Pkg.test("BinaryBuilder", coverage=true)'
 
 # Ironic.  He could provide binaries for others but not himself...
 addons:


### PR DESCRIPTION
Now that the sandbox is part of the rootfs, our CI currently
does not test changes to the sandbox anymore. Add a build
step that uses the sandbox from this repo.