### PR TITLE
Fix a call to canonicalize_source_url

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -241,7 +241,7 @@ function obtain_binary_deps(state::WizardState)
                 print(state.outs, "> ")
                 url = readline(state.ins)
                 println(state.outs)
-                canon_url = canonicalize_url(url)
+                canon_url = canonicalize_source_url(url)
                 if url != canon_url
                     print(state.outs, "The entered URL has been canonicalized to\n")
                     print_with_color(:bold, state.outs, canon_url)


### PR DESCRIPTION
Right now this errors. I think this is meant to call ``canonicalize_source_url``, but someone better double check.