### PR TITLE
Provide a fake `@__DIR__` so that remote `build.jl` files don't freak out

### DIFF
--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -204,6 +204,7 @@ function setup_workspace(build_path::AbstractString, src_paths::Vector,
             using BinaryProvider
             platform_key() = $platform
             macro write_deps_file(args...); end
+            macro __DIR__(args...); return $destdir; end
             install(args...; kwargs...) = BinaryProvider.install(args...; kwargs..., ignore_platform=true, verbose=$verbose)
             ARGS = [$destdir]
             include_string($(script))


### PR DESCRIPTION
This fixes the `joinpath(::Void, ::String)` method error you can get right now when using a relatively recent/fancy remote `build.jl` file.