### PR TITLE
Create new top-level abstraction `build_tarballs()`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,23 +36,22 @@ products(prefix) = [
 dependencies = []
 
 # Build 'em!
-autobuild(
-    pwd(),
+build_tarballs(
+    ARGS,
     "libfoo",
-    supported_platforms(),
     sources,
     script,
+    platforms,
     products,
-    dependencies;
-    verbose = true
+    dependencies,
 )
 ```
 
-This bare-bones snippet (an adapted form of the [`libfoo` test](../../test/build_libfoo_tarballs.jl) within this repository) first identifies the sources to download and compile (there can be multiple sources listed here), then lists the bash commands to actually build this particular project.  Next, the `products` are defined.  These represent the output of the build process, and are how `BinaryBuilder.jl` knows that its build has succeeded.  Finally, we pass this information off to `autobuild()`, which takes it all in and runs the builds, placing output tarballs into the `./products` directory.
+This bare-bones snippet (an adapted form of the [`libfoo` test](../../test/build_libfoo_tarballs.jl) within this repository) first identifies the sources to download and compile (there can be multiple sources listed here), then lists the bash commands to actually build this particular project.  Next, the `products` are defined.  These represent the output of the build process, and are how `BinaryBuilder.jl` knows that its build has succeeded.  Finally, we pass this information off to `build_tarballs()`, which takes it all in and runs the builds, placing output tarballs into the `./products` directory.
 
 The bash commands contained within `script` will be executed for each `platform` that is passed in, so if there are platform differences that need to be addressed in the build script, using `if` statements and the `$target` environment variable can be a powerful tool.  See the [OpenBLASBuilder build script](https://github.com/staticfloat/OpenBLASBuilder/blob/master/build_tarballs.jl) for an example showcasing this.
 
-Once the `autobuild()` method completes, it will return a `product_hashes` object which can be used to print out a template `build.jl` file to download and install the generated tarballs.  This file is what will be used in Julia packages that need to use your built binaries, and is typically included within the tagged release uploads from a builder repository.  Here is an example release from the [IpoptBuilder repository](https://github.com/staticfloat/IpoptBuilder/releases/tag/v3.12.8-9), containing built tarballs as well as a `build.jl` that can be used within `Ipopt.jl`.
+Once the `build_tarballs()` method completes, it will have written out a `build.jl` file to download and install the generated tarballs.  This file is what will be used in Julia packages that need to use your built binaries, and is typically included within the tagged release uploads from a builder repository.  Here is an example release from the [IpoptBuilder repository](https://github.com/staticfloat/IpoptBuilder/releases/tag/v3.12.8-9), containing built tarballs as well as a `build.jl` that can be used within `Ipopt.jl`.
 
 While constructing your own build script is certainly possible, `BinaryBuilder.jl` supports a more interactive method for building the binary dependencies and capturing the commands used to build it into a `build_tarballs.jl` file; the Wizard interface.
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1,27 +1,110 @@
-export autobuild, print_buildjl, product_hashes_from_github_release
+export build_tarballs, autobuild, print_buildjl, product_hashes_from_github_release
 import GitHub: gh_get_json, DEFAULT_API
 import SHA: sha256
+
+"""
+    build_tarballs(ARGS, src_name, sources, script, platforms, products,
+                   dependencies)
+
+This should be the top-level function called from a `build_tarballs.jl` file.
+It takes in the information baked into a `build_tarballs.jl` file such as the
+`sources` to download, the `products` to build, etc... and will automatically
+download, build and package the tarballs, generating a `build.jl` file when
+appropriate.  Note that `ARGS` should be the top-level Julia `ARGS` command-
+line arguments object.
+"""
+function build_tarballs(ARGS, src_name, sources, script, platforms, products,
+                        dependencies)
+    # This sets whether we should build verbosely or not
+    verbose = "--verbose" in ARGS
+    ARGS = filter!(x -> x != "--verbose", ARGS)
+
+    # This flag skips actually building and instead attempts to reconstruct a
+    # build.jl from a GitHub release page.  Use this to automatically deploy a
+    # build.jl file even when sharding targets across multiple CI builds.
+    only_buildjl = "--only-buildjl" in ARGS
+    ARGS = filter!(x -> x != "--only-buildjl", ARGS)
+
+    # If we're only reconstructing a build.jl file, we _need_ this information
+    # otherwise it's useless, so go ahead and error() out here.
+    if only_buildjl && (!all(haskey.(ENV, ["TRAVIS_REPO_SLUG", "TRAVIS_TAG"])))
+        msg = strip("""
+        Must provide repository name and tag through Travis-style environment
+        variables like TRAVIS_REPO_SLUG and TRAVIS_TAG!
+        """)
+        error(replace(msg, "\n" => " "))
+    end
+
+    # If the user passed in a platform (or a few, comma-separated) on the
+    # command-line, use that instead of our default platforms
+    should_override_platforms = length(ARGS) > 0
+    if should_override_platforms
+        platforms = platform_key.(split(ARGS[1], ","))
+    end
+
+    # If we're running on Travis and this is a tagged release, automatically
+    # determine bin_path by building up a URL, otherwise use a default value.
+    # The default value allows local builds to not error out
+    bin_path = "https:://<path to hosted binaries>"
+    if !isempty(get(ENV, "TRAVIS_TAG", ""))
+        repo_name = ENV["TRAVIS_REPO_SLUG"]
+        tag_name = ENV["TRAVIS_TAG"]
+        bin_path = "https://github.com/$(repo_name)/releases/download/$(tag_name)"
+    end
+
+    product_hashes = if !only_buildjl
+        # If the user didn't just ask for a `build.jl`, go ahead and actually build
+        info("Building for $(join(triplet.(platforms), ", "))")
+
+        # Build the given platforms using the given sources
+        autobuild(pwd(), src_name, platforms, sources, script,
+                         products, dependencies; verbose=verbose)
+    else
+        msg = strip("""
+        Reconstructing product hashes from GitHub Release $(repo_name)/$(tag_name)
+        """)
+        info(msg)
+
+        # Reconstruct product_hashes from github
+        product_hashes_from_github_release(repo_name, tag_name; verbose=verbose)
+    end
+
+    # If we didn't override the default set of platforms OR we asked for only
+    # a build.jl file, then write one out.  We don't write out when overriding
+    # the default set of platforms because that is typically done either while
+    # testing, or when we have sharded our tarball construction over multiple
+    # invocations.
+    if !should_override_platforms || only_buildjl
+        dummy_prefix = Prefix(pwd())
+        print_buildjl(pwd(), products(dummy_prefix), product_hashes, bin_path)
+
+        if verbose
+            info("Writing out the following reconstructed build.jl:")
+            print_buildjl(STDOUT, products(dummy_prefix), product_hashes, bin_path)
+        end
+    end
+end
 
 
 """
     autobuild(dir::AbstractString, src_name::AbstractString, platforms::Vector,
-              sources::Vector, script::AbstractString, products::Vector,
+              sources::Vector, script::AbstractString, products::Function,
               dependencies::Vector; verbose::Bool = true)
 
 Runs the boiler plate code to download, build, and package a source package
-for multiple platforms.  `src_name` represents the name of the source package
+for a list of platforms.  `src_name` represents the name of the source package
 being built (and will set the name of the built tarballs), `platforms` is a
 list of platforms to build for, `sources` is a list of tuples giving
 `(url, hash)` of all sources to download and unpack before building begins,
 `script` is a string representing a `bash` script to run to build the desired
-products, which are listed as `Product` objects within the vector `products`.
-`dependencies` gives a list of dependencies that provide `build.jl` files that
-should be installed before building begins to allow this build process to
-depend on the results of another build process.
+products, which are listed as `Product` objects within the vector returned by
+the `products` function. `dependencies` gives a list of dependencies that
+provide `build.jl` files that should be installed before building begins to
+allow this build process to depend on the results of another build process.
 """
 function autobuild(dir::AbstractString, src_name::AbstractString,
-                   platforms::Vector, sources::Vector, script::AbstractString,
-                   products::Vector,
+                   platforms::Vector, sources::Vector,
+                   script::AbstractString, products::Function,
                    dependencies::Vector = AbstractDependency[];
                    verbose::Bool = true)
     # If we're on Travis and we're not verbose, schedule a task to output a "." every few seconds
@@ -130,15 +213,12 @@ function autobuild(dir::AbstractString, src_name::AbstractString,
         println()
     end
 
-    # Finally, print out our awesome build.jl
-    Compat.@info("Use this as your deps/build.jl:")
-    print_buildjl(stdout, product_hashes)
-
-    product_hashes
+    # Return our product hashes
+    return product_hashes
 end
 
-function print_buildjl(io::IO, product_hashes::Dict; products::Vector{Product} = Product[],
-                       bin_path::AbstractString = "https://<path to hosted binaries>")
+function print_buildjl(io::IO, products::Vector, product_hashes::Dict,
+                       bin_path::AbstractString)
     print(io, """
     using BinaryProvider
 
@@ -147,25 +227,14 @@ function print_buildjl(io::IO, product_hashes::Dict; products::Vector{Product} =
     const prefix = Prefix(get([a for a in ARGS if a != "--verbose"], 1, joinpath(@__DIR__, "usr")))
     """)
 
-    # If we have been given products, print out the products we're given.  Otherwise, print out an example:
-    if isempty(products)
-        print(io, """
-        products = Product[
-            # Instantiate products here, e.g.:
-            # LibraryProduct(prefix, "libfoo", :libfoo),
-            # ExecutableProduct(prefix, "fooifier", :fooifier),
-            # FileProduct(joinpath(libdir(prefix), "pkgconfig", "libfoo.pc"), :libfoo_pc),
-        ]
-
-        """)
-    else
-        print(io, "products = Product[\n")
-        for prod in products
-            print(io, "    $(repr(prod)),\n")
-        end
-        print(io, "]\n\n")
+    # Print out products
+    print(io, "products = [\n")
+    for prod in products
+        print(io, "    $(repr(prod)),\n")
     end
+    print(io, "]\n\n")
 
+    # Print binary locations/tarball hashes
     print(io, """
     # Download binaries from hosted location
     bin_prefix = "$bin_path"
@@ -201,10 +270,11 @@ function print_buildjl(io::IO, product_hashes::Dict; products::Vector{Product} =
     """)
 end
 
-function print_buildjl(build_dir::AbstractString, products::Vector{Product}, product_hashes::Dict, bin_path::AbstractString)
+function print_buildjl(build_dir::AbstractString, products::Vector,
+                       product_hashes::Dict, bin_path::AbstractString)
     mkpath(joinpath(build_dir, "products"))
     open(joinpath(build_dir, "products", "build.jl"), "w") do io
-        print_buildjl(io, product_hashes; products=products, bin_path=bin_path)
+        print_buildjl(io, products, product_hashes, bin_path)
     end
 end
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -54,7 +54,7 @@ function build_tarballs(ARGS, src_name, sources, script, platforms, products,
 
     product_hashes = if !only_buildjl
         # If the user didn't just ask for a `build.jl`, go ahead and actually build
-        info("Building for $(join(triplet.(platforms), ", "))")
+        Compat.@info("Building for $(join(triplet.(platforms), ", "))")
 
         # Build the given platforms using the given sources
         autobuild(pwd(), src_name, platforms, sources, script,
@@ -63,7 +63,7 @@ function build_tarballs(ARGS, src_name, sources, script, platforms, products,
         msg = strip("""
         Reconstructing product hashes from GitHub Release $(repo_name)/$(tag_name)
         """)
-        info(msg)
+        Compat.@info(msg)
 
         # Reconstruct product_hashes from github
         product_hashes_from_github_release(repo_name, tag_name; verbose=verbose)
@@ -79,7 +79,7 @@ function build_tarballs(ARGS, src_name, sources, script, platforms, products,
         print_buildjl(pwd(), products(dummy_prefix), product_hashes, bin_path)
 
         if verbose
-            info("Writing out the following reconstructed build.jl:")
+            Compat.@info("Writing out the following reconstructed build.jl:")
             print_buildjl(STDOUT, products(dummy_prefix), product_hashes, bin_path)
         end
     end
@@ -295,7 +295,7 @@ function product_hashes_from_github_release(repo_name::AbstractString, tag_name:
             return true
         end
         if verbose
-            info("Ignoring file $(filename); can't extract its platform key")
+            Compat.@info("Ignoring file $(filename); can't extract its platform key")
         end
         return false
     end
@@ -320,7 +320,7 @@ function product_hashes_from_github_release(repo_name::AbstractString, tag_name:
             product_hashes[file_triplet] = (asset["name"], hash)
 
             if verbose
-                info("Calculated $hash for $(asset["name"])")
+                Compat.@info("Calculated $hash for $(asset["name"])")
             end
         end
     end

--- a/src/BinaryBuilder.jl
+++ b/src/BinaryBuilder.jl
@@ -9,6 +9,7 @@ using Nullables
 
 @reexport using BinaryProvider
 
+include("compat.jl")
 include("Auditor.jl")
 include("Runner.jl")
 include("RootFS.jl")

--- a/src/QemuRunner.jl
+++ b/src/QemuRunner.jl
@@ -195,7 +195,7 @@ function qemu_gen_cmd(qr::QemuRunner, cmd::Cmd, comm_socket_path::String)
     return `$long_cmd`
 end
 
-function Base.run(qr::QemuRunner, cmd, logpath::AbstractString; verbose::Bool = false, tee_stream=Compat.stdout)
+function Base.run(qr::QemuRunner, cmd, logpath::AbstractString; verbose::Bool = false, tee_stream=stdout)
     return temp_prefix() do prefix
         comm_socket_path = joinpath(prefix.path, "qemu_comm.socket")
         # Launch QEMU

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -83,7 +83,7 @@ function show(io::IO, x::UserNSRunner)
           "UserNSRunner")
 end
 
-function Base.run(ur::UserNSRunner, cmd, logpath::AbstractString; verbose::Bool = false, tee_stream=Compat.stdout)
+function Base.run(ur::UserNSRunner, cmd, logpath::AbstractString; verbose::Bool = false, tee_stream=stdout)
     if runner_override == "privileged"
         Compat.@info("Running privileged container via `sudo`, may ask for your password:")
     end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,11 @@
+## This is until we have a good replacement for `info(io, msg)` on 0.7+
+function info(io::IO, args...)
+    printstyled(io, "Info: "; color=Base.info_color())
+    printstyled(io, args...; color=Base.info_color())
+    println(io)
+end
+function warn(io::IO, args...)
+    printstyled(io, "Warning: "; color=Base.warn_color())
+    printstyled(io, args...; color=Base.warn_color())
+    println(io)
+end

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -387,10 +387,6 @@ function github_deploy(state::WizardState)
         # Create the GitHub repository
         gr = GitHub.create_repo(GitHub.Owner(PkgDev.GitHub.user()),
                 github_name; auth=auth)
-        # Append the build.jl generation on travis
-        open(joinpath(repo_dir, "build_tarballs.jl"), "a") do f
-            print_travis_buildjl(f, gr)
-        end
         # Push the empty commit
         LibGit2.push(repo, remoteurl="https://github.com/$(user)/$(github_name).git",
             payload=Nullable(LibGit2.UserPasswordCredentials(deepcopy(user),deepcopy(token))),

--- a/test/build_libfoo_tarballs.jl
+++ b/test/build_libfoo_tarballs.jl
@@ -1,37 +1,35 @@
 #!/usr/bin/env julia
 using BinaryBuilder
 
-# First, package up the libfoo source so `autobuild()` can take it:
+# First, package up the libfoo source so `build_tarballs()` can take it:
 src_prefix = Prefix("./build_tests/libfoo")
 src_tarball, src_hash = package(src_prefix, "./downloads/libfoo"; verbose=true, force=true)
 
-# Our sources are local, that's fine
+# Our sources are local.  No biggie.
 sources = [
     (src_tarball, src_hash)
 ]
 
-# Choose which platforms to build for; if we've got an argument use that one,
-# otherwise default to just building all of them!
-build_platforms = supported_platforms()
-if length(ARGS) > 0
-    build_platforms = platform_key.(split(ARGS[1], ","))
-end
-Compat.@info("Building for $(join(triplet.(build_platforms), ", "))")
+# Build script is very complicated.
+script = raw"""
+make install
+"""
 
+# By default, we build for all platforms.
+platforms = supported_platforms()
+
+# These are the products we care about
 products(prefix) = [
     LibraryProduct(prefix, "libfoo", :libfoo),
     ExecutableProduct(prefix, "fooifier", :fooifier)
 ]
 
-# Build 'em!
-autobuild(
-    pwd(),
-    "libfoo",
-    build_platforms,
-    sources,
-    "make install",
-    products,
-)
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs, and possibly a `build.jl` as well.
+build_tarballs(ARGS, "libfoo", sources, script, platforms, products, dependencies)
 
 # Cleanup temporary sources
 rm(src_tarball; force=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,11 +115,11 @@ end
     end
 end
 
-const libfoo_products = prefix->[
+libfoo_products(prefix) = [
     LibraryProduct(prefix, "libfoo", :libfoo)
     ExecutableProduct(prefix, "fooifier", :fooifier)
 ]
-const libfoo_script = """
+libfoo_script = """
 /usr/bin/make clean
 /usr/bin/make install
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,10 +178,10 @@ const libfoo_script = """
     rm("$(tarball_path).sha256"; force=true)
 end
 
-# Testset to make sure we can autobuild from a git repository
-@testset "AutoBuild Git-Based" begin
+# Testset to make sure we can build_tarballs() from a git repository
+@testset "build_tarballs() Git-Based" begin
     build_path = tempname()
-    git_path = joinpath(build_path,"libfoo.git")
+    git_path = joinpath(build_path, "libfoo.git")
     mkpath(git_path)
 
     cd(build_path) do
@@ -202,17 +202,19 @@ end
             LibGit2.hex(LibGit2.GitHash(commit)),
         ]
 
-        autobuild(
-            pwd(),
+        build_tarballs(
+            [], # fake ARGS
             "libfoo",
-            [Linux(:x86_64, :glibc)],
             sources,
             "cd libfoo\n$libfoo_script",
-            libfoo_products
+            [Linux(:x86_64, :glibc)],
+            libfoo_products,
+            [], # no dependencies
         )
 
         # Make sure that worked
         @test isfile("products/libfoo.x86_64-linux-gnu.tar.gz")
+        @test isfile("products/build.jl")
     end
 
     rm(build_path; force=true, recursive=true)


### PR DESCRIPTION
This greatly simplifies the `build_tarball.jl` files we've been
generating, bundling together the functionality that we have, so far,
been embedding in repositories scattered far and wide.  This also firms
up the rules of when a `build.jl` file is generated a little bit more.