### PR TITLE
Deal with `ecryptfs` directories

### DIFF
--- a/docs/src/environment_variables.md
+++ b/docs/src/environment_variables.md
@@ -8,10 +8,12 @@
 
 * `BINARYBUILDER_DOWNLOADS_CACHE`: When set to a path, cross-compiler shards will be downloaded to this location, instead of the default location of `<binarybuilder_root>/deps/downloads`.
 
-* `BINARYBUILDER_ROOTFS_DIR`: When set to a path, the base root FS will be unpacked/mounted to this location, instead of the default location of `<binarybuilder_root>/deps/root`.
+* `BINARYBUILDER_ROOTFS_DIR`: When set to a path, the base root FS will be unpacked/mounted to this location, instead of the default location of `<binarybuilder_root>/deps/root`.  Shards will be bind-mounted into this root directory, depending on the runner used.
 
-* `BINARYBUILDER_SHARDS_DIR`: When set to a path, cross-compiler shards will be unpacked/mounted to this location, instead of the default location of `<binarybuilder_root>/deps/shards`.
+* `BINARYBUILDER_SHARDS_DIR`: When set to a path, cross-compiler shards will be unpacked to this location, instead of the default location of `<binarybuilder_root>/deps/shards`.
 
 * `BINARYBUILDER_QEMU_DIR`: When set to a path, qemu/the linux kernel will be installed here (if using the `QemuRunner`) instead of the default location of `<binarybuilder_root>/deps/qemu`
 
 * `BINARYBUILDER_RUNNER`: When set to a runner string, alters the execution engine that `BinaryBuilder.jl` will use to wrap the build process in a sandbox.  Valid values are one of `"userns"`, `"privileged"` and `"qemu"`.  If not given, `BinaryBuilder.jl` will do its best to guess.
+
+* `BINARYBUILDER_ALLOW_ECRYPTFS`: When set to `true`, this allows the mounting of rootfs/shard/workspace directories from within encrypted mounts.  This is disabled by default, as at the time of writing, this triggers kernel bugs.  To avoid these kernel bugs on a system where e.g. the home directory has been encrypted, set the `BINARYBUILDER_ROOTFS_DIR` and `BINARYBUILDER_SHARDS_DIR` environment variables to a path outside of the encrypted home directory.

--- a/src/BinaryBuilder.jl
+++ b/src/BinaryBuilder.jl
@@ -88,7 +88,16 @@ function versioninfo()
     @static if Compat.Sys.isunix()
         Compat.@info("Kernel version: $(readchomp(`uname -r`))")
     end
-    Compat.@info("Preferred runner: $(preferred_runner())")
+
+    # Dump if the Pkg directory is encrypted:
+    @static if Compat.Sys.islinux()
+        is_encrypted, mountpoint = is_ecryptfs(dirname(@__FILE__))
+        if is_encrypted
+            Compat.@info("Package is encrypted on mountpoint $mountpoint")
+        else
+            Compat.@info("Package is NOT encrypted on mountpoint $mountpoint")
+        end
+    end
 
     # Dump any relevant environment variables:
     Compat.@info("Relevant envionment variables:")
@@ -107,6 +116,9 @@ function versioninfo()
             Compat.@info("  $(envvar): \"$(ENV[envvar])\"")
         end
     end
+
+    # Print out the preferred runner stuff here:
+    Compat.@info("Preferred runner: $(preferred_runner())")
 
     # Try to run 'echo julia' in Linux x86_64 environment
     Compat.@info("Trying to run `echo hello julia` within a Linux x86_64 environment...")

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -7,6 +7,7 @@ shards_cache = ""
 qemu_cache = ""
 automatic_apple = false
 use_squashfs = false
+allow_ecryptfs = false
 
 """
     downloads_dir(postfix::String = "")

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -35,7 +35,7 @@ end
 Builds a path relative to the `shards_cache`.
 """
 function shards_dir(postfix::String = "")
-    global shards_dir
+    global shards_cache
     return joinpath(shards_cache, postfix)
 end
 

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -175,6 +175,10 @@ function probe_unprivileged_containers(;verbose::Bool=false)
     # Ensure the base rootfs is available
     update_rootfs(String[]; verbose=false)
 
+    # Ensure we're not about to make fools of ourselves by trying to mount an
+    # encrypted directory, which triggers kernel bugs.  :(
+    check_encryption(pwd())
+
     # Construct an extremely simple sandbox command
     sandbox_cmd = `$(rootfs_dir("sandbox")) --rootfs $(rootfs_dir())`
     cmd = `$(sandbox_cmd) -- /bin/bash -c "echo hello julia"`

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -18,20 +18,20 @@ end
 function platform_def_mapping(platform)
     tp = triplet(platform)
     mapping = Pair{String,String}[
-        joinpath(shards_cache, tp) => joinpath("/opt", tp)
+        shards_dir(tp) => joinpath("/opt", tp)
     ]
 
     # We might also need the x86_64-linux-gnu platform for bootstrapping,
     # so make sure that's always included
     if platform != Linux(:x86_64)
         ltp = triplet(Linux(:x86_64))
-        push!(mapping, joinpath(shards_cache, ltp) => joinpath("/opt", ltp))
+        push!(mapping, shards_dir(ltp) => joinpath("/opt", ltp))
     end
 
     # If we're trying to run macOS and we have an SDK directory, mount that!
     if platform == MacOS()
         sdk_version = "MacOSX10.10.sdk"
-        sdk_shard_path = joinpath(shards_cache, sdk_version)
+        sdk_shard_path = shards_dir(sdk_version)
         push!(mapping, sdk_shard_path => joinpath("/opt", tp, sdk_version))
     end
 

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -239,6 +239,11 @@ end
 
 function check_encryption(workspace_root::AbstractString;
                           verbose::Bool = false)
+    # If we've explicitly allowed ecryptfs, just quit out immediately
+    global allow_ecryptfs
+    if allow_ecryptfs
+        return
+    end
     msg = []
     
     is_encrypted, mountpoint = is_ecryptfs(workspace_root; verbose=verbose)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,14 @@ end
     @test BinaryBuilder.target_proc_family("powerpc64le-linux-gnu") == "power"
 end
 
-# This file contains tests that require our cross-compilation environment
+@testset "UserNS utilities" begin
+    # Test that is_ecryptfs works for something we're certain isn't encrypted
+    isecfs = (false, "/proc/")
+    @test BinaryBuilder.is_ecryptfs("/proc"; verbose=true) == isecfs
+    @test BinaryBuilder.is_ecryptfs("/proc/"; verbose=true) == isecfs
+    @test BinaryBuilder.is_ecryptfs("/proc/not_a_file"; verbose=true) == isecfs
+end
+
 @testset "Builder Dependency" begin
     temp_prefix() do prefix
         # First, let's create a Dependency that just installs a file


### PR DESCRIPTION
This will error out if the user attempts to run the sandbox with any kind of bindmounting that would involve `ecryptfs` directories, which is the case on e.g. Ubuntu machines with encrypted home directories.  This is undesirable because it triggers kernel bugs. 