### PR TITLE
Override `write_deps_file()` when installing dependencies

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -187,6 +187,7 @@ function autobuild(dir::AbstractString, src_name::AbstractString,
                     using BinaryProvider
                     platform_key() = $platform
                     macro write_deps_file(args...); end
+                    function write_deps_file(args...); end
                     function install(url, hash;
                         prefix::Prefix = BinaryProvider.global_prefix,
                         kwargs...)

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -70,6 +70,10 @@ function target_envs(target::AbstractString)
         "proc_family" => target_proc_family(target),
         "TERM" => "screen",
 
+        # We should always be looking for packages already in the prefix
+        "PKG_CONFIG_PATH" => "/workspace/destdir/lib/pkgconfig",
+        "PKG_CONFIG_SYSROOT_DIR" => "/workspace/destdir",
+
         # Autotools really appreciates being able to build stuff for the
         # host system, so we set this to ease its woes
         "CC_FOR_BUILD" => "/opt/x86_64-linux-gnu/bin/gcc",

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -37,6 +37,9 @@ function target_envs(target::AbstractString)
     lib_path *= ":/opt/$(target)/lib64:/opt/$(target)/lib"
     lib_path *= ":/opt/$(target)/$(target)/lib64:/opt/$(target)/$(target)/lib"
 
+    # Finally add on our destination location
+    lib_path *= ":/workspace/destdir/lib64:/workspace/destdir/lib"
+
     # Start with the standard PATH:
     path = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -204,6 +204,7 @@ function setup_workspace(build_path::AbstractString, src_paths::Vector,
             using BinaryProvider
             platform_key() = $platform
             macro write_deps_file(args...); end
+            function write_deps_file(args...) end
             macro __DIR__(args...); return $destdir; end
             install(args...; kwargs...) = BinaryProvider.install(args...; kwargs..., ignore_platform=true, verbose=$verbose)
             ARGS = [$destdir]


### PR DESCRIPTION
Before merging this, add a test case to ensure that this doesn't break in the future.  The specific break was that when installing a dependent tarball, the `build.jl` would fail because the `deps.jl` file generation would fail, claiming that the requested products were unsatisfied, likely due to the fact that they were on the wrong stinkin' platform.