### PR TITLE
Use stty to change interrtupt when running interactive QEMU shell

### DIFF
--- a/src/QemuRunner.jl
+++ b/src/QemuRunner.jl
@@ -203,7 +203,7 @@ function Base.run(qr::QemuRunner, cmd, logpath::AbstractString; verbose::Bool = 
 
         oc = OutputCollector(cmd; verbose=verbose, tee_stream=tee_stream)
         did_succeed = wait(oc)
-
+        
         if !isempty(logpath)
             # Write out the logfile, regardless of whether it was successful
             mkpath(dirname(logpath))
@@ -254,7 +254,10 @@ function run_interactive(qr::QemuRunner, cmd::Cmd; stdin = nothing, stdout = not
 end
 
 function runshell(qr::QemuRunner, args...; kwargs...)
+    println("Setting parent shell interrupt to ^] (use ^C as usual, ^] to exit shell)")
+    @static if Compat.Sys.isapple() run(`stty intr ^\]`) end
     run_interactive(qr, `/bin/bash`, args...; kwargs...)
+    @static if Compat.Sys.isapple() run(`stty intr ^\C`) end
 end
 
 function runshell(::Type{QemuRunner}, platform::Platform = platform_key(); verbose::Bool = false)


### PR DESCRIPTION
ref #153. Maybe not the desired long-term fix, but this makes the macOS experience much less annoying.