### PR TITLE
more libs to ignore

### DIFF
--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -94,6 +94,9 @@ function should_ignore_lib(lib, ::ELFHandle)
     ignore_libs = [
         "libc.so.6",
         "libstdc++.so.6",
+        # POSIX libraries
+        "libdl.so.2",
+        "librt.so.1",
         # libgcc Linux and FreeBSD style
         "libgcc_s.1.so",
         "libgcc_s.so.1",


### PR DESCRIPTION
I guess the principle here is to ignore libraries that always ship with the OS?  If so, libdl and librt should qualify.