### PR TITLE
Translate absolute symlinks to relative in an audit pass

### DIFF
--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -2,6 +2,7 @@ export audit, collect_files, collapse_symlinks
 
 include("auditor/instruction_set.jl")
 include("auditor/dynamic_linkage.jl")
+include("auditor/symlink_translator.jl")
 
 # AUDITOR TODO LIST:
 #
@@ -39,6 +40,9 @@ function audit(prefix::Prefix; io=stderr,
 
     # If this is false then it's bedtime for bonzo boy
     all_ok = true
+
+    # Translate absolute symlinks to relative symlinks, if possible
+    translate_symlinks(prefix.path; verbose=verbose)
 
     # Inspect binary files, looking for improper linkage
     predicate = f -> (filemode(f) & 0o111) != 0 || valid_dl_path(f, platform)

--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -223,10 +223,16 @@ function audit(prefix::Prefix; io=stderr,
     # offense, as many files have absolute paths.  We want to know about it
     # though, so we'll still warn the user.
     for f in all_files
-        file_contents = String(read(f))
-        if contains(file_contents, prefix.path)
+        try
+            file_contents = String(read(f))
+            if contains(file_contents, prefix.path)
+                if !silent
+                    warn(io, "$(relpath(f, prefix.path)) contains an absolute path")
+                end
+            end
+        except
             if !silent
-                warn(io, "$(relpath(f, prefix.path)) contains an absolute path")
+                warn(io, "Skipping abspath scanning of $(f), as we can't open it")
             end
         end
     end

--- a/src/auditor/symlink_translator.jl
+++ b/src/auditor/symlink_translator.jl
@@ -1,0 +1,20 @@
+"""
+    translate_symlinks(root::AbstractString; verbose::Bool=false)
+
+Walks through the root directory given within `root`, finding all symlinks that
+point to an absolute path within `root`, and rewriting them to be a relative
+symlink instead, increasing relocatability.
+"""
+function translate_symlinks(root::AbstractString; verbose::Bool=false)
+    for f in collect_files(root, islink)
+        link_target = readlink(f)
+        if isabspath(link_target) && startswith(link_target, "/workspace")
+            new_link_target = relpath(link_target, replace(dirname(f), root, "/workspace/destdir"))
+            if verbose
+                Compat.@info("Translating $f to point to $(new_link_target)")
+            end
+            rm(f; force=true)
+            symlink(new_link_target, f)
+        end
+    end
+end


### PR DESCRIPTION
`Bzip2Builder` doesn't make good symlinks, they're all absolute.  No harm no foul, let's just automatically translate them.