### PR TITLE
Various fixes

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -234,10 +234,17 @@ function autobuild(dir::AbstractString, src_name::AbstractString,
                 # Once we're built up, go ahead and package this prefix out
                 tarball_path, tarball_hash = package(prefix, joinpath(out_path, src_name); platform=platform, verbose=verbose, force=true)
                 product_hashes[target] = (basename(tarball_path), tarball_hash)
+
+                # Destroy the prefix
+                rm(prefix.path; recursive=true)
             end
 
-            # Finally, destroy the build_path
-            rm(build_path; recursive=true)
+            # If the whole build_path is empty, then remove it too.  If it's not, it's probably
+            # because some other build is doing something simultaneously with this target, and we
+            # don't want to mess with their stuff.
+            if isempty(readdir(build_path))
+                rm(build_path; recursive=true)
+            end
         end
     end
 

--- a/src/Dependency.jl
+++ b/src/Dependency.jl
@@ -109,6 +109,13 @@ function build(runner, dep::Dependency; verbose::Bool = false, force::Bool = fal
             """, '\n' => ' ')
             error(strip(msg))
         end
+
+        # Finally, check to see if we are now satisfied
+        if !satisfied(dep; verbose=verbose)
+            if verbose
+                Compat.@warn("Built $(dep.name) but still unsatisfied!")
+            end
+        end
     elseif !should_build && verbose
         Compat.@info("Not building as $(dep.name) is already satisfied")
     end

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -106,6 +106,8 @@ function should_ignore_lib(lib, ::ELFHandle)
         # libpthread and libgomp are pretty safe bets
         "libpthread.so.0",
         "libgomp.so.1",
+        # dynamic loaders from our alpine environment
+        "ld-linux-x86-64.so.2",
     ]
     return lowercase(basename(lib)) in ignore_libs
 end

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -204,7 +204,6 @@ function setup_workspace(build_path::AbstractString, src_paths::Vector,
         eval(m, quote
             using BinaryProvider
             platform_key() = $platform
-            macro write_deps_file(args...); end
             function write_deps_file(args...) end
             macro __DIR__(args...); return $destdir; end
             install(args...; kwargs...) = BinaryProvider.install(args...; kwargs..., ignore_platform=true, verbose=$verbose)


### PR DESCRIPTION
* Fix two simultaneous builders occasionally stepping on eachother's toes

* Warn if, after a build, we still don't satisfy a particular product.  We're not making this fatal, but it will be if it is still the case after installation on a user's machine.

* Make the dependency uninstallation machinery more robust.