### PR TITLE
change build.jl to re-download when tarball hash changes

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -298,7 +298,7 @@ function print_buildjl(io::IO, products::Vector, product_hashes::Dict,
     unsatisfied = any(!satisfied(p; verbose=verbose) for p in products)
     if haskey(download_info, platform_key())
         url, tarball_hash = download_info[platform_key()]
-        if unsatisfied || !isinstalled(url, tarball_hash)
+        if unsatisfied || !isinstalled(url, tarball_hash; prefix=prefix)
             # Download and install binaries
             install(url, tarball_hash; prefix=prefix, force=true, verbose=verbose)
         end

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -263,7 +263,7 @@ end
 function print_buildjl(io::IO, products::Vector, product_hashes::Dict,
                        bin_path::AbstractString)
     print(io, """
-    using BinaryProvider
+    using BinaryProvider # requires BinaryProvider 0.3.0 or later
 
     # Parse some basic command-line arguments
     const verbose = "--verbose" in ARGS


### PR DESCRIPTION
As explained in JuliaPackaging/BinaryProvider.jl#59. 

Don't merge until a new version of BinaryProvider is tagged (to have the `isinstalled` function from JuliaPackaging/BinaryProvider.jl#60).

cc @staticfloat 