### PR TITLE
Fixed OSX toolchain, add FreeBSD/musl platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,14 @@ matrix:
 env:
   global:
     - BINARYBUILDER_AUTOMATIC_APPLE=true
+    - BINARYBUILDER_FULL_SHARD_TEST=false
   matrix:
-    - BINARYBUILDER_USE_SQUASHFS=true
+    # One test with squashfs, also doing a full shard test
+    - BINARYBUILDER_USE_SQUASHFS=true BINARYBUILDER_FULL_SHARD_TEST=true
+    # One test without squashfs.  We don't have the disk space
+    # available to do a full shard test here. :(
     - BINARYBUILDER_USE_SQUASHFS=false
+    # One test with the privileged runner, also 
     - BINARYBUILDER_RUNNER=privileged
 
 cache:
@@ -41,8 +46,11 @@ jobs:
 script:
    - julia -e 'Pkg.clone(pwd())'
    - julia -e 'Pkg.build("BinaryBuilder")'
-   - if [ ${TEST_SANDBOX:-false} = true ]; then julia -e 'cd(Pkg.dir("BinaryBuilder","deps")); run(`gcc -o root/sandbox sandbox.c`)'; fi
-   - julia --color=yes --check-bounds=yes -e 'Pkg.test("BinaryBuilder", coverage=true)'
+   - if [ ${TEST_SANDBOX:-false} = true ]; then
+        julia -e 'cd(Pkg.dir("BinaryBuilder","deps")); run(`gcc -o root/sandbox sandbox.c`)';
+     else
+        julia --color=yes --check-bounds=yes -e 'Pkg.test("BinaryBuilder", coverage=true)';
+     fi
 
 # Ironic.  He could provide binaries for others but not himself...
 addons:

--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -79,11 +79,10 @@ function audit(prefix::Prefix; io=stderr,
 
             # Look at every dynamic link, and see if we should do anything about that link...
             libs = find_libraries(oh)
+            ignored_libraries = String[]
             for libname in keys(libs)
                 if should_ignore_lib(libname, oh)
-                    if verbose
-                        info(io, "Ignoring system library $(libname)")
-                    end
+                    push!(ignored_libraries, libname)
                     continue
                 end
 
@@ -144,6 +143,10 @@ function audit(prefix::Prefix; io=stderr,
                     end
                     all_ok = false
                 end
+            end
+
+            if verbose && !isempty(ignored_libraries)
+                info(io, "Ignored system libraries $(join(ignored_libraries, ", "))")
             end
         end
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -237,8 +237,8 @@ function autobuild(dir::AbstractString, src_name::AbstractString,
                 tarball_path, tarball_hash = package(prefix, joinpath(out_path, src_name); platform=platform, verbose=verbose, force=true)
                 product_hashes[target] = (basename(tarball_path), tarball_hash)
 
-                # Destroy the prefix
-                rm(prefix.path; recursive=true)
+                # Destroy the workspace
+                rm(dirname(prefix.path); recursive=true)
             end
 
             # If the whole build_path is empty, then remove it too.  If it's not, it's probably

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -51,7 +51,7 @@ Returns the URL from which a rootfs image (tarball/squashfs) can be downloaded
 function get_shard_url(target::String = "base"; squashfs::Bool = use_squashfs)
     # These constants are what should be updated for a new rootfs build:
     rootfs_urlroot = "https://julialangmirror.s3.amazonaws.com/binarybuilder"
-    rootfs_version = "2018-04-01"
+    rootfs_version = "2018-04-11"
 
     shard_name = "rootfs-$(target)"
     ext = squashfs ? "squashfs" : "tar.gz"
@@ -70,34 +70,36 @@ function get_shard_hash(triplet::String = "base"; squashfs::Bool = use_squashfs)
     # in `julia-docker/crossbuild`, after running `make shards`.  Alternatively,
     # run `make push-rootfs` to do both and upload to S3
     squashfs_hashes = Dict(
-        "aarch64-linux-gnu" => "ecfcc6fa071dea7b7e0eba6994af5b02fc703bd1c8b99f902b1ef172171fb780",
-        "aarch64-linux-musl" => "96102a9acdb2f03f8a67003bf8762419cdc6109851075d6b1ea89d2317cb6116",
-        "arm-linux-gnueabihf" => "d0567cb77ae533c6f639c6d7ece40df3c9eea70fc1f79074c6a83cb5170cf24c",
-        "arm-linux-musleabihf" => "6d2dc85c638d2e4ed0487905bb0c2f013817f19413c89bf2f1259023de2cf467",
-        "base" => "155018ab628b17bc2c972f99b2725345cde43530a86dad6c7b6a838df08422dd",
-        "i686-linux-gnu" => "d4d1e7d886f057e75097a3c071fa9e0406dd377bd227ca7483147e0bf044af6e",
-        "i686-linux-musl" => "e72c1d34de87b73411174601f242121826c171785a4fb01d00502af0a7359099",
-        "i686-w64-mingw32" => "cdbb780f79d7e8b72580c729426e509cc75e628c919ce5a91f849b5120591a29",
-        "powerpc64le-linux-gnu" => "fa0c858ca9460a53490e82429efdeed2d1292931c1e0dc47d6e580b68263852e",
-        "x86_64-apple-darwin14" => "a637a44807e196d9191038afa744ff50b246d4ed8538d44b734bd6e38c154cd0",
-        "x86_64-linux-gnu" => "9c7881aadc990b310599f9873423b1d17c5cec91a34ee0d9ab5fafc28b10b77d",
-        "x86_64-linux-musl" => "7b55e23493adb02fd409cbab43e5febc8cedd3712ee19911610d38b231b16276",
-        "x86_64-w64-mingw32" => "afa89cd4f83cc94d8cc887d23c81579444627795d5e4dec8e9f4f454e84d525d",
+        "aarch64-linux-gnu" => "f0fd6793e329772dadee41298e3e408d43e6c5af6f43ea3bcdb0cabc94ba5e89",
+        "aarch64-linux-musl" => "67d3e6bc967bd4e058f533fac0ee62e535b2dee366e4bfddd50492ce94c8d0c3",
+        "arm-linux-gnueabihf" => "96daa95805974e7876f60468476d878613879aa1a390f55fb78a2c2ae3fc45dd",
+        "arm-linux-musleabihf" => "29f37b003277da768bbcd869d2a93c6588e9f3ab99e8ec96cd7c5e49cba57e3e",
+        "base" => "6248961bf057030055da502e3436025b40f27e11e410603c8fb0148ff04dcf9f",
+        "i686-linux-gnu" => "71788936b3b1e5f72a451a0974701851337a899d7ac557910240ea58917ca6c4",
+        "i686-linux-musl" => "acfcb756b7247b617b487bbe22df94f18d44e0dddc9f71c36ef311ffc9cb0367",
+        "i686-w64-mingw32" => "b04ae82fc3432a78825c57e32e86a7cb41ba9bf94fb21d75d8e0be91ef2a907c",
+        "powerpc64le-linux-gnu" => "4ba71b6e7969151189e9dfa870f48443d07b9b2cd68b0a268316067bc8a22845",
+        "x86_64-apple-darwin14" => "998408b0ba4060465b464648ca092fd5080d220b55d244c3821cbb19b5219edc",
+        "x86_64-linux-gnu" => "9dcec7f1092572eb9bddee43236fe0a9853ddba044425b01ff75ed162445f93f",
+        "x86_64-linux-musl" => "9639f19c735b426f355b073f5c2be1d6c6eb232791403bf99b3de270b8e325a3",
+        "x86_64-unknown-freebsd11.1" => "09a1ae3078c4e5f8fc43a728941674e9102f3697f78c026cf5a5725c08c742ed",
+        "x86_64-w64-mingw32" => "cbadda2aa1651f14cbe2cd5ccbc2d8bdb5d2e85aa7dbcbadc5232381de5daa6a",
     )
     tarball_hashes = Dict(
-        "aarch64-linux-gnu" => "08d491bff0039f81f76a2962c338e33ea67533209983c57c597aaac4ffe939a3",
-        "aarch64-linux-musl" => "4794b61ba4d673d34b7a7fe34d4a5866607ccdb6fd734ab28278c96ea5cbf7b5",
-        "arm-linux-gnueabihf" => "52e1fdd80d27ebf8f4dd693000d5096a6e166679eb6607b374e75c2c94fb16ec",
-        "arm-linux-musleabihf" => "5f123ca56362c5c7c8a1037a3d33d90cf4bca30780281f0a94240e20fd36f7dc",
-        "base" => "f797b579c98d181cffc8dca6aaab0f6f1c9084b750bcffbe9e6307132b1ab2de",
-        "i686-linux-gnu" => "90d418fe008f417200bd5317ec27ab1b34ffba661487d552477fa10081a6322f",
-        "i686-linux-musl" => "72aba030dd3c2e715af6da6eaefb7271b9fabc6ca42d01cfb6110dc053223def",
-        "i686-w64-mingw32" => "be6e62c47b16d4827e06d24062721510d0be8f7ed25731460d601a0591067e18",
-        "powerpc64le-linux-gnu" => "57dc54ed006b1578a0e0f10150225658d8c6777d47fb91be88ab5db4733c0be2",
-        "x86_64-apple-darwin14" => "7ba4e216282c4e4591bea808993f59d469fc8bf471622bd7d36886a96190b81f",
-        "x86_64-linux-gnu" => "24d6eed2f0ecac85637e478d324f08fc53f52cec3e01c528313cd4db527fb3f4",
-        "x86_64-linux-musl" => "362abc73138f9427f763d39c334e848e7bcb4000ab567799c45831f8cdc5ddb5",
-        "x86_64-w64-mingw32" => "f4e60e193222bd449f921aecc5754962ac0c8c3859c89787d7c310548e5689ad",
+        "aarch64-linux-gnu" => "09d689a60d3586c7ee2a6a728de739f2528a3cf66c9428760cf297f1cae63279",
+        "aarch64-linux-musl" => "85acd64e2fb7573c315f599f82b97361985ea63bd41a8b28c619f7888a61bda4",
+        "arm-linux-gnueabihf" => "d3ec1899669de05fb85702f11b41495dbc8306d8857ba6254b4063b18674d71b",
+        "arm-linux-musleabihf" => "9f37d189ef990c407e47be874036bd4980a0fca2d1658d1b83587370dd5830ff",
+        "base" => "b9650d11d86a5386d2b5fe3ce295659da89b98226c2488c399a620402d2a853a",
+        "i686-linux-gnu" => "ed8c0344d90b092907d736e0c74018f3c3a493a7a6c1525f6f48b0469fdda408",
+        "i686-linux-musl" => "8acf68e05dc734fcfd16bd1f8cf50b20dacf9937891ca0928392e6c3406ec051",
+        "i686-w64-mingw32" => "4b5a3956707baf34efb897e79f032c41c693618dba5e6fb529d46a6bc2cc3728",
+        "powerpc64le-linux-gnu" => "979826644b009549d933d44febf8773e35292765e1c99253ba86fe14fe3f5468",
+        "x86_64-apple-darwin14" => "698c918e32d31cd5c0d6017fc451c8916a9f0e1b2d9b041812848de1508f90cb",
+        "x86_64-linux-gnu" => "1118c434a14016da6eaeb1c8f0c7bea30aed9f98cc7c5847634aba92bd5f8ffc",
+        "x86_64-linux-musl" => "5954553d2fb0d7404e0054686ef3e76edaa17ac771869f73b6e4ee687174aa87",
+        "x86_64-unknown-freebsd11.1" => "f60a91e897f38455ee76f4fb74d87148635270b5a65211e571d79f3c8fb929c7",
+        "x86_64-w64-mingw32" => "ddf230129b6785a21bac0cb60b167d7f7aa2633e27c376a9f4601aac9f5de0b0",
     )
 
     if squashfs

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -53,7 +53,7 @@ Returns the URL from which a rootfs image (tarball/squashfs) can be downloaded
 function get_shard_url(target::String = "base"; squashfs::Bool = use_squashfs)
     # These constants are what should be updated for a new rootfs build:
     rootfs_urlroot = "https://julialangmirror.s3.amazonaws.com/binarybuilder"
-    rootfs_version = "2018-04-11"
+    rootfs_version = "2018-04-18"
 
     shard_name = "rootfs-$(target)"
     ext = squashfs ? "squashfs" : "tar.gz"
@@ -72,38 +72,37 @@ function get_shard_hash(triplet::String = "base"; squashfs::Bool = use_squashfs)
     # in `julia-docker/crossbuild`, after running `make shards`.  Alternatively,
     # run `make push-rootfs` to do both and upload to S3
     squashfs_hashes = Dict(
-        "aarch64-linux-gnu" => "f0fd6793e329772dadee41298e3e408d43e6c5af6f43ea3bcdb0cabc94ba5e89",
-        "aarch64-linux-musl" => "67d3e6bc967bd4e058f533fac0ee62e535b2dee366e4bfddd50492ce94c8d0c3",
-        "arm-linux-gnueabihf" => "96daa95805974e7876f60468476d878613879aa1a390f55fb78a2c2ae3fc45dd",
-        "arm-linux-musleabihf" => "29f37b003277da768bbcd869d2a93c6588e9f3ab99e8ec96cd7c5e49cba57e3e",
-        "base" => "6248961bf057030055da502e3436025b40f27e11e410603c8fb0148ff04dcf9f",
-        "i686-linux-gnu" => "71788936b3b1e5f72a451a0974701851337a899d7ac557910240ea58917ca6c4",
-        "i686-linux-musl" => "acfcb756b7247b617b487bbe22df94f18d44e0dddc9f71c36ef311ffc9cb0367",
-        "i686-w64-mingw32" => "b04ae82fc3432a78825c57e32e86a7cb41ba9bf94fb21d75d8e0be91ef2a907c",
-        "powerpc64le-linux-gnu" => "4ba71b6e7969151189e9dfa870f48443d07b9b2cd68b0a268316067bc8a22845",
-        "x86_64-apple-darwin14" => "998408b0ba4060465b464648ca092fd5080d220b55d244c3821cbb19b5219edc",
-        "x86_64-linux-gnu" => "9dcec7f1092572eb9bddee43236fe0a9853ddba044425b01ff75ed162445f93f",
-        "x86_64-linux-musl" => "9639f19c735b426f355b073f5c2be1d6c6eb232791403bf99b3de270b8e325a3",
-        "x86_64-unknown-freebsd11.1" => "09a1ae3078c4e5f8fc43a728941674e9102f3697f78c026cf5a5725c08c742ed",
-        "x86_64-w64-mingw32" => "cbadda2aa1651f14cbe2cd5ccbc2d8bdb5d2e85aa7dbcbadc5232381de5daa6a",
+        "aarch64-linux-gnu" => "5d74076eee99e7b7999db32a5f8ecd44403645a4929cd5df520cdb03b02087e2",
+        "aarch64-linux-musl" => "f55c57eeb877d2c045d32c2fc64e01738b3a4af64bbe39a11984a24b33a9c8d0",
+        "arm-linux-gnueabihf" => "b99256205ba5698acbaa368a86d562048247ebd14b2b77e60dac4803970d0b24",
+        "arm-linux-musleabihf" => "444fa9986406f33e36841403c5c207f2890dc8ec4f90ad7bd2ca0a83a9876770",
+        "base" => "3f2fd58cc3bc5b23c50d8b395ddbd5d4df0e8a62d2c2f52f9323a20cb17553a6",
+        "i686-linux-gnu" => "97041a593b2973ac24d0a9a4c677faebc57161b34a77ee2dfd8cd36c60ad2540",
+        "i686-linux-musl" => "0230ccf69edf79964a5395219eb787ea55af3eb64f2fc74b25ad58e962fdd483",
+        "i686-w64-mingw32" => "1d2b0b0f05c1c67fdeaefe8245e20c8ee24323c2a87e962b6a0ae3efd2b6671b",
+        "powerpc64le-linux-gnu" => "697dbed010596cf2ebb2346dba2da56d71167287d7ce30ab98c8a9e3d3c195b9",
+        "x86_64-apple-darwin14" => "f7cd46f0f71a9544d8d4ce2cead3db524a8b354a1520a1893c4b2c531eff61c1",
+        "x86_64-linux-gnu" => "35f95e2ec777d5b4cfd9dddb43beef12d2be6758a17624ac838d97ea3269f3f5",
+        "x86_64-linux-musl" => "0c4ddd014949dc1a3332e03569d4b9fa8989fe5903c095ea580c05c22c8b9210",
+        "x86_64-unknown-freebsd11.1" => "fb5571556255bea30fa7b286266d2415bb64f30f999d998b769242d55dd32b84",
+        "x86_64-w64-mingw32" => "2a3467d3aaf3780696ff4ca7b36da42f7de8065438f4c202db635eb3929eb4be",
     )
     tarball_hashes = Dict(
-        "aarch64-linux-gnu" => "09d689a60d3586c7ee2a6a728de739f2528a3cf66c9428760cf297f1cae63279",
-        "aarch64-linux-musl" => "85acd64e2fb7573c315f599f82b97361985ea63bd41a8b28c619f7888a61bda4",
-        "arm-linux-gnueabihf" => "d3ec1899669de05fb85702f11b41495dbc8306d8857ba6254b4063b18674d71b",
-        "arm-linux-musleabihf" => "9f37d189ef990c407e47be874036bd4980a0fca2d1658d1b83587370dd5830ff",
-        "base" => "b9650d11d86a5386d2b5fe3ce295659da89b98226c2488c399a620402d2a853a",
-        "i686-linux-gnu" => "ed8c0344d90b092907d736e0c74018f3c3a493a7a6c1525f6f48b0469fdda408",
-        "i686-linux-musl" => "8acf68e05dc734fcfd16bd1f8cf50b20dacf9937891ca0928392e6c3406ec051",
-        "i686-w64-mingw32" => "4b5a3956707baf34efb897e79f032c41c693618dba5e6fb529d46a6bc2cc3728",
-        "powerpc64le-linux-gnu" => "979826644b009549d933d44febf8773e35292765e1c99253ba86fe14fe3f5468",
-        "x86_64-apple-darwin14" => "698c918e32d31cd5c0d6017fc451c8916a9f0e1b2d9b041812848de1508f90cb",
-        "x86_64-linux-gnu" => "1118c434a14016da6eaeb1c8f0c7bea30aed9f98cc7c5847634aba92bd5f8ffc",
-        "x86_64-linux-musl" => "5954553d2fb0d7404e0054686ef3e76edaa17ac771869f73b6e4ee687174aa87",
-        "x86_64-unknown-freebsd11.1" => "f60a91e897f38455ee76f4fb74d87148635270b5a65211e571d79f3c8fb929c7",
-        "x86_64-w64-mingw32" => "ddf230129b6785a21bac0cb60b167d7f7aa2633e27c376a9f4601aac9f5de0b0",
+        "aarch64-linux-gnu" => "f8611c11b5fbb1453ca64714a625eabc186bee0d3471b87da635e41b22480c10",
+        "aarch64-linux-musl" => "a6758c423c1d9c77724d90ec182eed9063becd882b3bdebf849913f4ec37365a",
+        "arm-linux-gnueabihf" => "64aabdb6c300294f464a821d847b60d83054a2d89953c5d6a8648b01850f4a80",
+        "arm-linux-musleabihf" => "9f2231dc90cb844ad10c17ff3284869744179871db75f776d4a0c933e4076c33",
+        "base" => "ad16b4c514bf0b5efd6a3422c233f2b8c9e9a7afe647661c06618a9d963f73e8",
+        "i686-linux-gnu" => "11f9b1193e140fd42e9d11aedbcaa6c9066a201771cebc0a55bad2f1a6357fe2",
+        "i686-linux-musl" => "a06f2381058b718a56302921fc0a560a47d09f776f0c7caf9a4eee026762044d",
+        "i686-w64-mingw32" => "f99c43b80906b1b6a3100d2b685aa3b40932bd299e78ce21ee922cceec31880b",
+        "powerpc64le-linux-gnu" => "c9ccf51d18b34854c18a40f079381327016eeb631e5f3e578f5a3f39ba7de51b",
+        "x86_64-apple-darwin14" => "a4dec3e0efbffd2e4a15b963fd0163701e2aeaf4fdb71eb05b5b692a6839363c",
+        "x86_64-linux-gnu" => "c661c3b2d04face54ffec210b3abdb742b3dc77c9c5b53bfa75b25979410f45e",
+        "x86_64-linux-musl" => "06628287f2bf567105a3ab2fa603796a595739891caeccde1ea2b5c9a2aca605",
+        "x86_64-unknown-freebsd11.1" => "930d6c9c08fed688235b6956925861130596acbeb88532a68c9a508482b09edb",
+        "x86_64-w64-mingw32" => "7891c322d378f27741bd618465bce51770b919795c9d1ab739b8372d59b26271",
     )
-
     if squashfs
         return squashfs_hashes[triplet]
     else

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -142,15 +142,6 @@ function supported_platforms()
     ]
 end
 
-# Note: produce these values by #including squashfs_fs.h from linux in Cxx.jl
-# and running the indicated command
-const offsetof_id_table_start = 0x30    # offsetof(struct suqashfs_super_block, id_table_start)
-const offsetof_no_ids = 0x1a            # offsetof(struct suqashfs_super_block, no_ids)
-
-# From squashfs_fs.h
-const SQUASHFS_COMPRESSED_BIT = UInt16(1) << 15
-const SQUASHFS_MAGIC = 0x73717368
-
 """
     getuid()
 
@@ -159,6 +150,15 @@ Wrapper around libc's `getuid()` function
 function getuid()
     return ccall(:getuid, Cint, ())
 end
+
+# Note: produce these values by #including squashfs_fs.h from linux in Cxx.jl
+# and running the indicated command
+const offsetof_id_table_start = 0x30    # offsetof(struct suqashfs_super_block, id_table_start)
+const offsetof_no_ids = 0x1a            # offsetof(struct suqashfs_super_block, no_ids)
+
+# From squashfs_fs.h
+const SQUASHFS_COMPRESSED_BIT = UInt16(1) << 15
+const SQUASHFS_MAGIC = 0x73717368
 
 """
     rewrite_squashfs_uids(path, new_uid)

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -1,3 +1,5 @@
+export supported_platforms
+
 # These globals store important information such as where we're downloading
 # the rootfs to, and where we're unpacking it.  These constants are initialized
 # by `__init__()` to allow for environment variable overrides from the user.
@@ -107,6 +109,38 @@ function get_shard_hash(triplet::String = "base"; squashfs::Bool = use_squashfs)
     else
         return tarball_hashes[triplet]
     end
+end
+
+"""
+    supported_platforms()
+
+Return the list of supported platforms as an array of `Platform`s.  These are the platforms we
+officially support building for, if you see a mapping in `get_shard_hash()` that isn't
+represented here, it's probably because that platform is still considered "in beta".
+"""
+function supported_platforms()
+    return [
+        # glibc Linuces
+        Linux(:i686),
+        Linux(:x86_64),
+        Linux(:aarch64),
+        Linux(:armv7l),
+        Linux(:powerpc64le),
+
+        # musl Linuces
+        Linux(:i686, :musl),
+        Linux(:x86_64, :musl),
+        Linux(:aarch64, :musl),
+        Linux(:armv7l, :musl),
+
+        # BSDs
+        MacOS(:x86_64),
+        FreeBSD(:x86_64),
+
+        # Windows
+        Windows(:i686),
+        Windows(:x86_64),
+    ]
 end
 
 # Note: produce these values by #including squashfs_fs.h from linux in Cxx.jl

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -82,12 +82,14 @@ function target_envs(target::AbstractString)
         "CC_FOR_BUILD" => "/opt/x86_64-linux-gnu/bin/gcc",
     )
 
-    # If we're on OSX, default to clang instead of gcc for CC and CXX
+    # If we're on OSX or FreeBBSD, default to clang for CC and CXX
     # Also default to asking for a minimum of OSX 10.8 for C++ ABI
-    if contains(target, "-apple-")
+    if contains(target, "-apple-") || contains(target, "-freebsd")
         mapping["CC"] = "/opt/$(target)/bin/clang"
         mapping["CXX"] = "/opt/$(target)/bin/clang++"
-        mapping["LDFLAGS"] = "-mmacosx-version-min=10.8"
+        if contains(target, "-apple-")
+            mapping["LDFLAGS"] = "-mmacosx-version-min=10.8"
+        end
     end
 
     return mapping

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -101,10 +101,15 @@ function target_envs(target::AbstractString)
         mapping["NM"] = target_tool("nm")
     end
 
-    # On OSX ask for a minimum of OSX 10.8 for C++ ABI (This is default now?)
-    #if contains(target, "-apple-")
-    #    mapping["LDFLAGS"] = "-mmacosx-version-min=10.8"
-    #end
+    # On OSX, we need to do a little more work.
+    if contains(target, "-apple-")
+        # First, tell CMake what our deployment target is, so that it tries to
+        # set -mmacosx-version-min and such appropriately
+        mapping["MACOSX_DEPLOYMENT_TARGET"] = "10.8"
+
+        # Also put this into LDFLAGS because some packages are hard of hearing
+        mapping["LDFLAGS"] = "-mmacosx-version-min=10.8"
+    end
 
     return mapping
 end

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -103,7 +103,8 @@ end
 
 function Base.run(ur::UserNSRunner, cmd, logpath::AbstractString; verbose::Bool = false, tee_stream=stdout)
     if runner_override == "privileged"
-        Compat.@info("Running privileged container via `sudo`, may ask for your password:")
+        msg = "Running privileged container via `sudo`, may ask for your password:"
+        BinaryProvider.info_onchange(msg, "privileged", "userns_run_privileged")
     end
 
     did_succeed = true
@@ -129,7 +130,8 @@ end
 
 function run_interactive(ur::UserNSRunner, cmd::Cmd; stdin = nothing, stdout = nothing, stderr = nothing)
     if runner_override == "privileged"
-        Compat.@info("Running privileged container via `sudo`, may ask for your password:")
+        msg = "Running privileged container via `sudo`, may ask for your password:"
+        BinaryProvider.info_onchange(msg, "privileged", "userns_run_privileged")
     end
 
     cd(rootfs_dir()) do

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -92,6 +92,8 @@ end
 # These are libraries we should straight-up ignore, like libsystem on OSX
 function should_ignore_lib(lib, ::ELFHandle)
     ignore_libs = [
+        # Basic runtimes
+        "libc.so",
         "libc.so.6",
         "libstdc++.so.6",
         # POSIX libraries

--- a/src/auditor/instruction_set.jl
+++ b/src/auditor/instruction_set.jl
@@ -1212,7 +1212,7 @@ function analyze_instruction_set(oh::ObjectHandle; verbose::Bool = false, io::IO
             the proper instruction set internally.  Would have chosen
             $(min_isa), instead choosing $(new_min_isa).
             """, '\n' => ' ')
-            Compat.@warn(io, strip(msg))
+            warn(io, strip(msg))
         end
         return new_min_isa
     end

--- a/src/auditor/instruction_set.jl
+++ b/src/auditor/instruction_set.jl
@@ -1205,7 +1205,7 @@ function analyze_instruction_set(oh::ObjectHandle; verbose::Bool = false, io::IO
     # return the most conservative ISA and warn the user if `verbose` is set.
     if counts["cpuid"] > 0
         new_min_isa = is64bit(oh) ? :core2 : :pentium4
-        if verbose
+        if verbose && new_min_isa != min_isa
             msg = replace("""
             $(basename(path(oh))) contains a `cpuid` instruction; refusing to
             analyze for minimum instruction set, as it may dynamically select

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ end
     begin
         build_path = tempname()
         mkpath(build_path)
-        prefix, ur = BinaryBuilder.setup_workspace(build_path, [], [], [], platform_key())
+        prefix, ur = BinaryBuilder.setup_workspace(build_path, [], [], [], platform)
         cd(joinpath(dirname(@__FILE__),"build_tests","libfoo")) do
             run(`cp $(readdir()) $(joinpath(prefix.path,"..","srcdir"))/`)
 
@@ -166,7 +166,7 @@ libfoo_script = """
     begin
         build_path = tempname()
         mkpath(build_path)
-        prefix, ur = BinaryBuilder.setup_workspace(build_path, [], [], [], platform_key())
+        prefix, ur = BinaryBuilder.setup_workspace(build_path, [], [], [], platform)
         cd(joinpath(dirname(@__FILE__),"build_tests","libfoo")) do
             run(`cp $(readdir()) $(joinpath(prefix.path,"..","srcdir"))/`)
 
@@ -202,6 +202,24 @@ libfoo_script = """
 
     rm(tarball_path; force=true)
     rm("$(tarball_path).sha256"; force=true)
+end
+
+@testset "Shard sanity tests" begin
+    for shard_platform in supported_platforms()
+        build_path = tempname()
+        mkpath(build_path)
+        prefix, ur = BinaryBuilder.setup_workspace(build_path, [], [], [], shard_platform)
+        cd(joinpath(dirname(@__FILE__),"build_tests","libfoo")) do
+            run(`cp $(readdir()) $(joinpath(prefix.path,"..","srcdir"))/`)
+
+            # Build libfoo, warn if we fail
+            dep = Dependency("foo", libfoo_products(prefix), libfoo_script, shard_platform, prefix)
+            @test build(ur, dep)
+        end
+
+        # Delete the build path
+        rm(build_path, recursive = true)
+    end
 end
 
 # Testset to make sure we can build_tarballs() from a local directory


### PR DESCRIPTION
Lots of goodies in this one, including much better macOS C++ toolchain setup, FreeBSD and musl linux shards, as well as the products of a completely new shard buildsystem.

Many thanks to @wdv4758h and @ararslan for their help getting the FreeBSD toolchain setup!