### PR TITLE
Change relinking to use `$ORIGIN` and `@rpath` properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,21 +22,29 @@ env:
     - BINARYBUILDER_AUTOMATIC_APPLE=true
     - BINARYBUILDER_FULL_SHARD_TEST=false
   matrix:
-    # One test with squashfs, also doing a full shard test
+    # Test with squashfs, also doing a full shard test
     - BINARYBUILDER_USE_SQUASHFS=true BINARYBUILDER_FULL_SHARD_TEST=true
-    # One test without squashfs.  We don't have the disk space
-    # available to do a full shard test here. :(
-    - BINARYBUILDER_USE_SQUASHFS=false
-    # One test with the privileged runner, also 
-    - BINARYBUILDER_RUNNER=privileged
 
+    # Add a job that uses squashfs and also runs the package tests
+    - BINARYBUILDER_USER_SQUASHFS=true BINARYBUILDER_PACKAGE_TESTS=true
 cache:
   directories:
     - deps/downloads
 
-# Add a test job that builds a new version of the sandbox.
 jobs:
   include:
+    # Add a job that doesn't use the squashfs but otherwise does normal tests
+    # We don't have the disk space available to do a full shard test here.
+    - julia: 0.6
+      env:
+        - BINARYBUILDER_USE_SQUASHFS=false
+
+    # Add a job that uses the privileged builder
+    - julia: 0.6
+      env:
+        - BINARYBUILDER_RUNNER=privileged
+
+    # Add a test job that builds a new version of the sandbox.
     - stage: test
       julia: 0.6
       env:

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -268,8 +268,12 @@ function autobuild(dir::AbstractString, src_name::AbstractString,
                 # Don't keep the downloads directory around
                 rm(joinpath(prefix, "downloads"); force=true, recursive=true)
 
+                # Collect dependency manifests so that our auditing doesn't touch these files that
+                # were installed by dependencies
+                dep_manifests = [joinpath(prefix, "manifests", f) for f in readdir(joinpath(prefix, "manifests"))]
+
                 dep = Dependency(src_name, products(prefix), script, platform, prefix)
-                if !build(ur, dep; verbose=verbose, autofix=true)
+                if !build(ur, dep; verbose=verbose, autofix=true, ignore_manifests=dep_manifests)
                     error("Failed to build $(target)")
                 end
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -270,7 +270,12 @@ function autobuild(dir::AbstractString, src_name::AbstractString,
 
                 # Collect dependency manifests so that our auditing doesn't touch these files that
                 # were installed by dependencies
-                dep_manifests = [joinpath(prefix, "manifests", f) for f in readdir(joinpath(prefix, "manifests"))]
+                manifest_dir = joinpath(prefix, "manifests")
+                dep_manifests = if isdir(manifest_dir)
+                   [joinpath(prefix, "manifests", f) for f in readdir(manifest_dir)]
+                else
+                    String[]
+                end
 
                 dep = Dependency(src_name, products(prefix), script, platform, prefix)
                 if !build(ur, dep; verbose=verbose, autofix=true, ignore_manifests=dep_manifests)

--- a/src/Dependency.jl
+++ b/src/Dependency.jl
@@ -75,7 +75,8 @@ warnings can be automatically fixed, and this will be attempted if `autofix` is
 set to `true`.
 """
 function build(runner, dep::Dependency; verbose::Bool = false, force::Bool = false,
-               autofix::Bool = false, ignore_audit_errors::Bool = true)
+               autofix::Bool = false, ignore_audit_errors::Bool = true,
+               ignore_manifests::Vector = [])
     # First, look to see whether this dependency is satisfied or not
     should_build = !satisfied(dep)
 
@@ -100,7 +101,8 @@ function build(runner, dep::Dependency; verbose::Bool = false, force::Bool = fal
 
         # Run an audit of the prefix to ensure it is properly relocatable
         audit_result = audit(dep.prefix; platform=dep.platform,
-                             verbose=verbose, autofix=autofix) 
+                             verbose=verbose, autofix=autofix,
+                             ignore_manifests=ignore_manifests) 
         if !audit_result && !ignore_audit_errors
             msg = replace("""
             Audit failed for $(dep.prefix.path).

--- a/test/package_tests/.gitignore
+++ b/test/package_tests/.gitignore
@@ -1,0 +1,2 @@
+builder_repos/
+package_repos/

--- a/test/package_tests/runtests.jl
+++ b/test/package_tests/runtests.jl
@@ -1,13 +1,14 @@
 using BinaryProvider
-using Base.Test
+using Compat
+using Compat.Test
 
 function pull_latest(url, dir)
     # Get the repo that we've already cloned, or clone a new one
     repo = if !isdir(dir)
-        info("Cloning $(basename(url))")
+        Compat.@info("Cloning $(basename(url))")
         LibGit2.clone(url, dir)
     else
-        info("Updating $(basename(url))")
+        Compat.@info("Updating $(basename(url))")
         LibGit2.GitRepo(dir)
     end
 
@@ -29,7 +30,7 @@ function clone_build_test(builder_url, package_url, package_deps)
     # Build for the current platform
     try
         product_hashes = cd(builder_dir) do
-            info("Building $(basename(builder_url))")
+            Compat.@info("Building $(basename(builder_url))")
             m = Module(:__anon__)
             eval(m, quote
                 trip = $(triplet(platform_key()))
@@ -60,10 +61,10 @@ function clone_build_test(builder_url, package_url, package_deps)
     pkg_env = merge(ENV, Dict("JULIA_LOAD_PATH" => join(pkg_src_dirs, ':')))
 
     # Copy over the new build.jl file and build it
-    cp(joinpath(builder_dir, "products", "build.jl"), joinpath(package_dir, "deps", "build.jl"); remove_destination=true)
+    Compat.cp(joinpath(builder_dir, "products", "build.jl"), joinpath(package_dir, "deps", "build.jl"); force=true)
 
     try
-        info("Building $(basename(package_url))")
+        Compat.@info("Building $(basename(package_url))")
         run(setenv(`$(Base.julia_cmd()) $(joinpath(package_dir, "deps", "build.jl"))`, pkg_env))
     catch e
        display(e)
@@ -73,7 +74,7 @@ function clone_build_test(builder_url, package_url, package_deps)
 
     # Finally, test that package!
     try
-        info("Testing $(basename(package_url))")
+        Compat.@info("Testing $(basename(package_url))")
         cd(joinpath(package_dir, "test")) do
             run(setenv(`$(Base.julia_cmd()) runtests.jl`, pkg_env))
         end

--- a/test/package_tests/runtests.jl
+++ b/test/package_tests/runtests.jl
@@ -1,0 +1,113 @@
+using BinaryProvider
+using Base.Test
+
+function pull_latest(url, dir)
+    # Get the repo that we've already cloned, or clone a new one
+    repo = if !isdir(dir)
+        info("Cloning $(basename(url))")
+        LibGit2.clone(url, dir)
+    else
+        info("Updating $(basename(url))")
+        LibGit2.GitRepo(dir)
+    end
+
+    # Fetch latest changes
+    LibGit2.fetch(repo)
+    
+    # Reset ourselves onto the latest `master`
+    master_oid = LibGit2.GitCommit(repo, "remotes/origin/master")
+    LibGit2.reset!(repo, master_oid, LibGit2.Consts.RESET_HARD)
+    return nothing
+end
+
+# live_laugh_love(;irony=false)
+function clone_build_test(builder_url, package_url, package_deps)
+    # First, check out the builder and start building it
+    builder_dir = abspath(joinpath("builder_repos", basename(builder_url)))
+    pull_latest(builder_url, builder_dir)
+
+    # Build for the current platform
+    try
+        product_hashes = cd(builder_dir) do
+            info("Building $(basename(builder_url))")
+            m = Module(:__anon__)
+            eval(m, quote
+                trip = $(triplet(platform_key()))
+                ARGS = [trip]
+                product_hashes = include(joinpath($(builder_dir), "build_tarballs.jl"))
+
+                # Write out a build.jl file that points to this tarball
+                bin_path = joinpath($(builder_dir), "products")
+                BinaryBuilder.print_buildjl($(builder_dir), products(Prefix(bin_path)), product_hashes, bin_path)
+            end)
+        end
+    catch e
+        display(e)
+        warn("Building $(basename(builder_url)) failed.")
+        return false
+    end
+
+    # Next, check out the package and its deps
+    pkg_src_dirs = String[]
+    for dep_url in package_deps
+        dep_dir = abspath(joinpath("package_repos", basename(dep_url)))
+        pull_latest(dep_url, dep_dir)
+        push!(pkg_src_dirs, joinpath(dep_dir, "src"))
+    end
+    package_dir = abspath(joinpath("package_repos", basename(package_url)))
+    pull_latest(package_url, package_dir)
+    push!(pkg_src_dirs, joinpath(package_dir, "src"))
+    pkg_env = merge(ENV, Dict("JULIA_LOAD_PATH" => join(pkg_src_dirs, ':')))
+
+    # Copy over the new build.jl file and build it
+    cp(joinpath(builder_dir, "products", "build.jl"), joinpath(package_dir, "deps", "build.jl"); remove_destination=true)
+
+    try
+        info("Building $(basename(package_url))")
+        run(setenv(`$(Base.julia_cmd()) $(joinpath(package_dir, "deps", "build.jl"))`, pkg_env))
+    catch e
+       display(e)
+        warn("Building $(basename(package_url)) failed.")
+        return false
+    end
+
+    # Finally, test that package!
+    try
+        info("Testing $(basename(package_url))")
+        cd(joinpath(package_dir, "test")) do
+            run(setenv(`$(Base.julia_cmd()) runtests.jl`, pkg_env))
+        end
+    catch e
+        display(e)
+        warn("Testing $(basename(package_url)) failed.")
+        return false
+    end
+    return true
+end
+
+
+
+# Some test cases that ensure we can build and pass tests on a few different packages
+test_cases = [
+    # This awaiting the merging of https://github.com/davidanthoff/SnappyBuilder/pull/1
+    #("https://github.com/davidanthoff/SnappyBuilder", "https://github.com/bicycle1885/Snappy.jl", []),
+    ("https://github.com/staticfloat/OggBuilder", "https://github.com/staticfloat/Ogg.jl", []),
+    ("https://github.com/staticfloat/NettleBuilder", "https://github.com/staticfloat/Nettle.jl", []),
+    ("https://github.com/bicycle1885/ZlibBuilder", "https://github.com/bicycle1885/CodecZlib.jl", ["https://github.com/bicycle1885/TranscodingStreams.jl"]),
+    ("https://github.com/JuliaWeb/MbedTLSBuilder", "https://github.com/JuliaWeb/MbedTLS.jl", []),
+    # This awaiting https://github.com/dancasimiro/WAV.jl/pull/59
+    #("https://github.com/staticfloat/FLACBuilder", "https://github.com/dmbates/FLAC.jl", ["https://github.com/staticfloat/Ogg.jl", "https://github.com/JuliaIO/FileIO.jl", "https://github.com/dancasimiro/WAV.jl"]),
+]
+
+mkpath("builder_repos")
+mkpath("package_repos")
+
+# Check everything out
+@testset "Ecosystem tests" begin
+    for (builder_url, package_url, package_deps) in test_cases
+        @testset "$(basename(package_url))" begin
+            @test clone_build_test(builder_url, package_url, package_deps)
+        end
+    end
+end
+

--- a/test/package_tests/runtests.jl
+++ b/test/package_tests/runtests.jl
@@ -92,7 +92,7 @@ end
 test_cases = [
     # This awaiting the merging of https://github.com/davidanthoff/SnappyBuilder/pull/1
     #("https://github.com/davidanthoff/SnappyBuilder", "https://github.com/bicycle1885/Snappy.jl", []),
-    ("https://github.com/staticfloat/OggBuilder", "https://github.com/staticfloat/Ogg.jl", []),
+    ("https://github.com/staticfloat/OggBuilder", "https://github.com/staticfloat/Ogg.jl", ["https://github.com/JuliaIO/FileIO.jl"]),
     ("https://github.com/staticfloat/NettleBuilder", "https://github.com/staticfloat/Nettle.jl", []),
     ("https://github.com/bicycle1885/ZlibBuilder", "https://github.com/bicycle1885/CodecZlib.jl", ["https://github.com/bicycle1885/TranscodingStreams.jl"]),
     ("https://github.com/JuliaWeb/MbedTLSBuilder", "https://github.com/JuliaWeb/MbedTLS.jl", []),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -420,3 +420,10 @@ end
 end
 
 include("wizard.jl")
+
+# Run the package tests if we ask for it
+if lowercase(get(ENV, "BINARYBUILDER_PACKAGE_TESTS", "false") ) == "true"
+    cd("package_tests") do
+        include(joinpath(pwd(), "runtests.jl"))
+    end
+end


### PR DESCRIPTION
@andreasnoack I think this change is necessary to get `ArpackBuilder` working; it changes a bit how we do our linking, so this isn't going to get merged very quickly because I still need to go through some of our larger customers and make sure that they are still able to build after this change, but I can at least `Libdl.dlopen("libarpack.so")` successfully if I build it with this branch.