### PR TITLE
Cause all errors to stop the build

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,7 +272,7 @@ end
             [], # fake ARGS
             "libfoo",
             sources,
-            "cd libfoo\n$libfoo_script",
+            libfoo_script,
             [Linux(:x86_64, :glibc)],
             libfoo_products,
             [], # no dependencies


### PR DESCRIPTION
This is a significant increase in strictness, however now that we have `--debug` it's doable.

With this change, any command that comes back nonzero (e.g. a failed patch, or an `rm foo` when `foo` does not exist) will cause the build to end.  Running with `--debug` will, of course, still drop into a buildshell, but this should significantly reduce confusion when, for example, patches stop applying cleanly because of an upgraded version.