### PR TITLE
Add `dlext` environment variable to build environment

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -18,6 +18,16 @@ function target_proc_family(target::AbstractString)
     end
 end
 
+function target_dlext(target::AbstractString)
+    if endswith(target, "-mingw32")
+        return "dll"
+    elseif contains(target, "-apple-")
+        return "dylib"
+    else
+        return "so"
+    end
+end
+
 """
     target_envs(target::String)
 
@@ -66,6 +76,7 @@ function target_envs(target::AbstractString)
         "nproc" => "$(Sys.CPU_CORES)",
         "nbits" => target_nbits(target),
         "proc_family" => target_proc_family(target),
+        "dlext" => target_dlext(target),
         "TERM" => "screen",
 
         # We should always be looking for packages already in the prefix

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,12 @@ end
         @test BinaryBuilder.target_proc_family(t) == "arm"
     end
     @test BinaryBuilder.target_proc_family("powerpc64le-linux-gnu") == "power"
+
+    for t in ["aarch64-linux-gnu", "x86_64-unknown-freebsd11.1"]
+        @test BinaryBuilder.target_dlext(t) == "so"
+    end
+    @test BinaryBuilder.target_dlext("x86_64-apple-darwin14") == "dylib"
+    @test BinaryBuilder.target_dlext("i686-w64-mingw32") == "dll"
 end
 
 @testset "UserNS utilities" begin


### PR DESCRIPTION
To be used as: `mv libfoo.so libfoo.${dlext}`, for buildsystems that hardcode `.so` onto the ends of shared libraries, for example.