### PR TITLE
Version output products

### DIFF
--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -132,6 +132,7 @@ function should_ignore_lib(lib, ::ELFHandle)
         # Basic runtimes for both Linux and FreeBSD
         "libc.so",
         "libc.so.6",
+        "libc.so.7",
         "libstdc++.so.6",
         "libdl.so.2",
         "librt.so.1",

--- a/src/wizard/state.jl
+++ b/src/wizard/state.jl
@@ -45,6 +45,7 @@ mutable struct WizardState
     validated_platforms::Set{Any}
     # Filled in by step 7
     name::Union{Nothing, String}
+    version::Union{Nothing, VersionNumber}
     github_api::GitHub.GitHubAPI
     travis_endpoint::String
 end
@@ -70,6 +71,7 @@ function WizardState()
         Set{Any}(),
         Set{Any}(),
         Set{Any}(),
+        nothing,
         nothing,
         GitHub.DEFAULT_API,
         DEFAULT_TRAVIS_ENDPOINT

--- a/test/package_tests/runtests.jl
+++ b/test/package_tests/runtests.jl
@@ -28,18 +28,20 @@ function clone_build_test(builder_url, package_url, package_deps)
     pull_latest(builder_url, builder_dir)
 
     # Build for the current platform
-    try
-        product_hashes = cd(builder_dir) do
+    name, version, product_hashes = try
+        cd(builder_dir) do
             Compat.@info("Building $(basename(builder_url))")
             m = Module(:__anon__)
             eval(m, quote
-                trip = $(triplet(platform_key()))
-                ARGS = [trip]
+                ARGS = [$(triplet(platform_key()))]
                 product_hashes = include(joinpath($(builder_dir), "build_tarballs.jl"))
 
                 # Write out a build.jl file that points to this tarball
                 bin_path = joinpath($(builder_dir), "products")
-                BinaryBuilder.print_buildjl($(builder_dir), products(Prefix(bin_path)), product_hashes, bin_path)
+                BinaryBuilder.print_buildjl($(builder_dir), name, version, products(Prefix(bin_path)), product_hashes, bin_path)
+
+                # Return back these three pieces of information
+                return name, version, product_hashes
             end)
         end
     catch e
@@ -61,7 +63,7 @@ function clone_build_test(builder_url, package_url, package_deps)
     pkg_env = merge(ENV, Dict("JULIA_LOAD_PATH" => join(pkg_src_dirs, ':')))
 
     # Copy over the new build.jl file and build it
-    Compat.cp(joinpath(builder_dir, "products", "build.jl"), joinpath(package_dir, "deps", "build.jl"); force=true)
+    Compat.cp(joinpath(builder_dir, "products", "build_$(name).v$(version).jl"), joinpath(package_dir, "deps", "build.jl"); force=true)
 
     try
         Compat.@info("Building $(basename(package_url))")
@@ -90,14 +92,15 @@ end
 
 # Some test cases that ensure we can build and pass tests on a few different packages
 test_cases = [
-    # This awaiting the merging of https://github.com/davidanthoff/SnappyBuilder/pull/1
-    #("https://github.com/davidanthoff/SnappyBuilder", "https://github.com/bicycle1885/Snappy.jl", []),
     ("https://github.com/staticfloat/OggBuilder", "https://github.com/staticfloat/Ogg.jl", ["https://github.com/JuliaIO/FileIO.jl"]),
     ("https://github.com/staticfloat/NettleBuilder", "https://github.com/staticfloat/Nettle.jl", []),
-    ("https://github.com/bicycle1885/ZlibBuilder", "https://github.com/bicycle1885/CodecZlib.jl", ["https://github.com/bicycle1885/TranscodingStreams.jl"]),
-    ("https://github.com/JuliaWeb/MbedTLSBuilder", "https://github.com/JuliaWeb/MbedTLS.jl", []),
+    # These disabled until they get updated with versioned outputs
+    #("https://github.com/bicycle1885/ZlibBuilder", "https://github.com/bicycle1885/CodecZlib.jl", ["https://github.com/bicycle1885/TranscodingStreams.jl"]),
+    #("https://github.com/JuliaWeb/MbedTLSBuilder", "https://github.com/JuliaWeb/MbedTLS.jl", []),
     # This segfaults for some reason.
     #("https://github.com/staticfloat/IpoptBuilder", "https://github.com/JuliaOpt/Ipopt.jl", ["https://github.com/JuliaOpt/MathProgBase.jl", "https://github.com/JuliaOpt/MathOptInterface.jl"]),
+    # This awaiting the merging of https://github.com/davidanthoff/SnappyBuilder/pull/1
+    #("https://github.com/davidanthoff/SnappyBuilder", "https://github.com/bicycle1885/Snappy.jl", []),
     # This awaiting https://github.com/dancasimiro/WAV.jl/pull/59
     #("https://github.com/staticfloat/FLACBuilder", "https://github.com/dmbates/FLAC.jl", ["https://github.com/staticfloat/Ogg.jl", "https://github.com/JuliaIO/FileIO.jl", "https://github.com/dancasimiro/WAV.jl"]),
 ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,7 +183,7 @@ libfoo_script = """
         end
 
         # Next, package it up as a .tar.gz file
-        tarball_path, tarball_hash = package(prefix, "./libfoo"; verbose=true)
+        tarball_path, tarball_hash = package(prefix, "./libfoo", v"1.0.0"; verbose=true)
         @test isfile(tarball_path)
 
         # Delete the build path
@@ -273,6 +273,7 @@ end
         build_tarballs(
             [], # fake ARGS
             "libfoo",
+            v"1.0.0",
             [local_dir_path],
             libfoo_script,
             [Linux(:x86_64, :glibc)],
@@ -281,8 +282,8 @@ end
         )
 
         # Make sure that worked
-        @test isfile("products/libfoo.x86_64-linux-gnu.tar.gz")
-        @test isfile("products/build.jl")
+        @test isfile("products/libfoo.v1.0.0.x86_64-linux-gnu.tar.gz")
+        @test isfile("products/build_libfoo.v1.0.0.jl")
     end
 end
 
@@ -313,6 +314,7 @@ end
         build_tarballs(
             [], # fake ARGS
             "libfoo",
+            v"1.0.0",
             sources,
             "cd libfoo\n$libfoo_script",
             [Linux(:x86_64, :glibc)],
@@ -321,8 +323,8 @@ end
         )
 
         # Make sure that worked
-        @test isfile("products/libfoo.x86_64-linux-gnu.tar.gz")
-        @test isfile("products/build.jl")
+        @test isfile("products/libfoo.v1.0.0.x86_64-linux-gnu.tar.gz")
+        @test isfile("products/build_libfoo.v1.0.0.jl")
     end
 
     rm(build_path; force=true, recursive=true)
@@ -336,7 +338,7 @@ end
         repo = LibGit2.clone("https://github.com/staticfloat/OggBuilder", ".")
 
         # Check out a known-good tag
-        LibGit2.checkout!(repo, hex(LibGit2.GitHash(LibGit2.GitCommit(repo, "v1.3.3-4"))))
+        LibGit2.checkout!(repo, hex(LibGit2.GitHash(LibGit2.GitCommit(repo, "v1.3.3-6"))))
 
         # Reconstruct binaries!  We don't want it to pick up BinaryBuilder.jl information from CI,
         # so wipe out those environment variables through withenv:
@@ -358,19 +360,19 @@ end
             function write_deps_file(args...; kwargs...); end
 
             # Include build.jl file to extract download_info
-            include(joinpath($build_path, "products", "build.jl"))
+            include(joinpath($build_path, "products", "build_Ogg.v1.3.3.jl"))
             download_info
         end)
 
         # Test that we get the info right about some of these platforms
-        bin_prefix = "https://github.com/staticfloat/OggBuilder/releases/download/v1.3.3-4"
+        bin_prefix = "https://github.com/staticfloat/OggBuilder/releases/download/v1.3.3-6"
         @test download_info[Linux(:x86_64)] == (
-            "$bin_prefix/Ogg.x86_64-linux-gnu.tar.gz",
-            "e4562248c27c8d4beb7f954fa02bf551e4908e448d825fa3f326ba92d947930c",
+            "$bin_prefix/Ogg.v1.3.3.x86_64-linux-gnu.tar.gz",
+            "6ef771242553b96262d57b978358887a056034a3c630835c76062dca8b139ea6",
         )
         @test download_info[Windows(:i686)] == (
-            "$bin_prefix/Ogg.i686-w64-mingw32.tar.gz",
-            "d76691afe57af2b01292478a6eaa6623149341318bbc559b69032cbfb328f974",
+            "$bin_prefix/Ogg.v1.3.3.i686-w64-mingw32.tar.gz",
+            "3f6f6f524137a178e9df7cb5ea5427de6694c2a44ef78f1491d22bd9c6c8a0e8",
         )
     end
 end


### PR DESCRIPTION
This embeds versions into output tarball and build.jl files.  This is a breaking change, as `build_tarballs.jl` files now must pass in a `version` to `build_tarballs()`.  