### PR TITLE
ignore missing platforms of a binary dependency

### DIFF
--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -504,7 +504,10 @@ function step5c(state::WizardState)
                 verbose=false,
                 tee_stream=state.outs
             )
-            prefix == nothing && (ok = false; return)
+            if prefix == nothing
+                ok = false
+                return
+            end
             run(ur,
                 `/bin/bash -c $(state.history)`,
                 joinpath(build_path,"out.log");

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -494,7 +494,6 @@ function step5c(state::WizardState)
         build_path = tempname()
         mkpath(build_path)
         local ok = true
-        local skip = false
         cd(build_path) do
             prefix, ur = setup_workspace(
                 build_path,
@@ -505,7 +504,7 @@ function step5c(state::WizardState)
                 verbose=false,
                 tee_stream=state.outs
             )
-            prefix == nothing && (skip = false; return)
+            prefix == nothing && (ok = false; return)
             run(ur,
                 `/bin/bash -c $(state.history)`,
                 joinpath(build_path,"out.log");

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -528,10 +528,6 @@ function step5c(state::WizardState)
                 silent = true
             ))
         end
-        if skip
-            warn("Falure with build $platform")
-            continue
-        end
         print(state.outs, "[")
         if ok
             printstyled(state.outs, "✓", color=:green)


### PR DESCRIPTION
Possibly the worst fix possible, but I thought it's slightly more useful than just opening an issue.
