### PR TITLE
audit should check all dynamic links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
    - if [ ${TEST_SANDBOX:-false} = true ]; then
          julia -e 'cd(Pkg.dir("BinaryBuilder","deps")); run(`gcc -std=c99 -o /tmp/sandbox sandbox.c`)';
      fi
-   - julia -e 'Pkg.checkout("BinaryProvider", "master")'
+   - julia -e 'Pkg.add("BinaryProvider")'
    - julia --color=yes --check-bounds=yes -e 'Pkg.test("BinaryBuilder", coverage=true)'
 
 # Ironic.  He could provide binaries for others but not himself...

--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -208,6 +208,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
                                verbose::Bool = false,
                                silent::Bool = false,
                                autofix::Bool = true)
+    all_ok = true
     # If it's a dynamic binary, check its linkage
     if isdynamic(oh)
         rp = RPath(oh)
@@ -248,7 +249,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
                         # If it is, point to that file instead!
                         new_link = update_linkage(prefix, platform, path(oh), libs[libname], bin_files[kidx]; verbose=verbose)
 
-                        if verbose
+                        if verbose && new_link !== nothing
                             msg = replace("""
                             Linked library $(libname) has been auto-mapped to
                             $(new_link)
@@ -263,7 +264,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
                         if !silent
                             warn(io, strip(msg))
                         end
-                        return false
+                        all_ok = false
                     end
                 else
                     msg = replace("""
@@ -273,7 +274,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
                     if !silent
                         warn(io, strip(msg))
                     end
-                    return false
+                    all_ok = false
                 end
             elseif !startswith(libs[libname], prefix.path)
                 msg = replace("""
@@ -283,7 +284,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
                 if !silent
                     warn(io, strip(msg))
                 end
-                return false
+                all_ok = false
             end
         end
 
@@ -291,7 +292,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
             info(io, "Ignored system libraries $(join(ignored_libraries, ", "))")
         end
     end
-    return true
+    return all_ok
 end
 
 


### PR DESCRIPTION
I was debuging a [builder](https://github.com/felipenoris/mongo-c-driver-builder) for libmongoc library and got stuck on a dyn lib that depends on another dyn lib that is built from the same source tar.

It turns out you already solved it at branch bb8. What I'm suggesting is to merge this to master as a bugfix for current version.