### PR TITLE
write_deps_file stubs now accept keyword args

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -398,7 +398,7 @@ function autobuild(dir::AbstractString,
                         using BinaryProvider
                         # Override BinaryProvider functionality so that it doesn't actually install anything
                         platform_key() = $platform
-                        function write_deps_file(args...); end
+                        function write_deps_file(args...; kwargs...); end
                         function install(args...; kwargs...); end
 
                         # Include build.jl file to extract download_info

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -245,7 +245,7 @@ function setup_workspace(build_path::AbstractString, src_paths::Vector,
             platform_key() = $platform
 
             # We don't want any deps files being written out
-            function write_deps_file(args...) end
+            function write_deps_file(args...; kwargs...) end
 
             # Override @__DIR__ to return the destination directory,
             # so that things get installed into there.  This is a protection


### PR DESCRIPTION
the real function accepts kwargs, but these stubs did not, so if the
user's dependent build.jl used a keyword argument it would crash out
while setting up the workspace