### PR TITLE
[WIP] adds `url_hash` convenience function

### DIFF
--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -27,3 +27,7 @@ At the time of writing, we support Linux (x86_64, i686, armv7l, aarch64, ppc64le
 ### At line XXX, ABORTED (Operation not permitted)!
 
 Some linux distributions have a bug in their `overlayfs` implementation that prevents us from mounting overlay filesystems within user namespaces.  See [this Ubuntu kernel bug report](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1531747) for a description of the situation and how Ubuntu has patched it in their kernels.  To work around this, you can launch `BinaryBuilder.jl` in "privileged container" mode.  Unfortunately, this involves running `sudo` every time you launch into a BinaryBuilder session, but on the other hand, this successfully works around the issue on distributions such as Arch linux.  To set "privileged container" mode, set the `BINARYBUILDER_RUNNER` environment variable to `privileged`.
+
+### Is there a convenient way to compute the hash of a remote file when I'm writing a `build_tarballs.jl` manually?
+
+Yes! Check out the `url_hash(url::String)` function, which is exported as a convenience function from `BinaryBuilder.jl`

--- a/src/BinaryBuilder.jl
+++ b/src/BinaryBuilder.jl
@@ -9,6 +9,7 @@ using Nullables
 using GitHub
 
 @reexport using BinaryProvider
+export url_hash
 
 include("compat.jl")
 include("Auditor.jl")
@@ -206,6 +207,13 @@ function versioninfo()
             platform=Linux(:x86_64),
         )
         run_interactive(runner, `/usr/local/bin/ccache -s`)
+    end
+end
+
+function url_hash(url::AbstractString)
+    path = download(url)
+    open(path) do io
+        bytes2hex(BinaryProvider.sha256(io))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,7 +61,7 @@ end
               "powerpc64le-linux-gnu", "x86_64-apple-darwin14"]
         @test BinaryBuilder.target_nbits(t) == "64"
     end
-    
+
     for t in ["x86_64-linux-gnu", "x86_64-apple-darwin14", "i686-w64-mingw32"]
         @test BinaryBuilder.target_proc_family(t) == "intel"
     end
@@ -388,7 +388,7 @@ end
         main_avx = ExecutableProduct(prefix, "main_avx", :main_avx)
         main_avx2 = ExecutableProduct(prefix, "main_avx2", :main_avx2)
         products = [main_sse, main_avx, main_avx2]
-        
+
         cd(joinpath(dirname(@__FILE__),"build_tests","isa_tests")) do
             run(`cp $(readdir()) $(joinpath(prefix.path,"..","srcdir"))/`)
 
@@ -522,6 +522,12 @@ end
         @test product_platform == true_product_platform
         @test product_hashes[target][2] == true_product_hashes[target][2]
     end
+end
+
+@testset "URL Hashing convenience function" begin
+    bin_prefix = "https://github.com/staticfloat/OggBuilder/releases/download/v1.3.3-6"
+    @test url_hash("$bin_prefix/Ogg.v1.3.3.x86_64-linux-gnu.tar.gz") ==
+        "6ef771242553b96262d57b978358887a056034a3c630835c76062dca8b139ea6"
 end
 
 include("wizard.jl")


### PR DESCRIPTION
Talked to @SimonDanisch about this in slack - seems like it's a thing people want to be able to do. I'm not 100% sure whether this belongs more in BinaryBuilder or BinaryProvider, but I figured this makes sense because you usually will need it in the context of writing a `build_tarballs.jl`

