### PR TITLE
`LibGit2.get(cfg, key, default)` doesn't mix types

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ ObjectFile 0.3.0
 Reexport
 MbedTLS
 GitHub
-PkgLicenses
+PkgLicenses 0.2.0
 JSON
 HTTP 0.6.3
 ProgressMeter

--- a/src/RootFS.jl
+++ b/src/RootFS.jl
@@ -324,7 +324,16 @@ function update_rootfs(triplets::Vector{S}; automatic::Bool = automatic_apple,
             # If it has been mounted previously, unmount here
             unmount_shard(dest_dir; verbose=verbose)
 
-             # If tarball, verify/redownload/reunpack the tarball
+            # It is possible that we used to have a .squashfs mounted here, and when we switch from
+            # .squashfs -> .tar.gz, we end up with an empty mountpoint directory.  This causes the
+            # `download_verify_unpack()` call to think the destination already exists.  We don't
+            # want that, so what we do is just delete an empty mountpoint if it exists.
+            try
+                rm(dest_dir; force=true, recursive=false)
+            catch
+            end
+
+            # If tarball, verify/redownload/reunpack the tarball
             download_verify_unpack(
                 url,
                 hash,

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -306,11 +306,20 @@ function common_git_repo_setup(repo_dir, repo, state)
         break
     end
 
+    # Helper function to get around LibGit2's strange `get()` behavior
+    function lg2get(T, cfg, name)
+        try
+            return LibGit2.get(T, cfg, name)
+        catch
+            return nothing
+        end
+    end
+
     # check to see if the user has already setup git config settings
-    if (LibGit2.get(state.global_git_cfg, "user.name", nothing) == nothing ||
-        LibGit2.get(state.global_git_cfg, "user.email", nothing) == nothing) &&
-        (LibGit2.getconfig(repo, "user.name", nothing) == nothing) ||
-        (LibGit2.getconfig(repo, "user.email", nothing) == nothing)
+    if (lg2get(state.global_git_cfg, "user.name") == nothing ||
+        lg2get(state.global_git_cfg, "user.email") == nothing) &&
+        (LibGit2.getconfig(repo, "user.name", nothing) == nothing ||
+         LibGit2.getconfig(repo, "user.email", nothing) == nothing)
         # If they haven't, prompt them to make a global one, and then actually
         # make a repository-local config right now.
         init_git_config(repo, state)

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -310,8 +310,11 @@ function common_git_repo_setup(repo_dir, repo, state)
     function lg2get(T, cfg, name)
         try
             return LibGit2.get(T, cfg, name)
-        catch
-            return nothing
+        catch e
+            if typeof(e) <: GitError
+                return nothing
+            end
+            rethrow(e)
         end
     end
 


### PR DESCRIPTION
Write our own version to do what we want.  Also fix logic problems.  This should fix https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/340