### PR TITLE
[WIP] Initial fix for #396

### DIFF
--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -429,7 +429,7 @@ end
 function push_repo(api::GitHub.GitHubWebAPI, lrepo, rrepo, user, token, refspecs)
     # Push the empty commit
     LibGit2.push(lrepo, remoteurl="https://github.com/$(GitHub.name(rrepo)).git",
-        payload=Nullable(LibGit2.UserPasswordCredentials(deepcopy(user),deepcopy(token))),
+        credentials=LibGit2.UserPasswordCredential(deepcopy(user),deepcopy(token)),
         refspecs=refspecs)
 end
 


### PR DESCRIPTION
Here's my attempt at fixing #396. I was able to BinaryBuilder to configure GitHub and Travis correctly. However, while it *does* complete successfully, the following error is logged:

```
Enter your desired license [MIT]:
┌ Warning: a SecretBuffer was `shred!`ed by the GC; use `shred!` manually after use to minimize exposure.
└ @ Base secretbuffer.jl:169
┌ Error: Exception while generating log record in module Base at secretbuffer.jl:169
│   exception =
│    task switch not allowed from inside gc finalizer
│    Stacktrace:
│     [1] try_yieldto(::typeof(Base.ensure_rescheduled), ::Base.RefValue{Task}) at ./event.jl:187
│     [2] wait() at ./event.jl:255
│     [3] uv_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:782
│     [4] unsafe_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:830
│     [5] macro expansion at ./io.jl:509 [inlined]
│     [6] write(::Base.TTY, ::Array{UInt8,1}) at ./io.jl:532
│     [7] #handle_message#2(::Nothing, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::String, ::Symbol, ::String, ::Int64) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Logging/src/ConsoleLogger.jl:161
│     [8] handle_message(::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::String, ::Symbol, ::String, ::Int64) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Logging/src/ConsoleLogger.jl:100
│     [9] macro expansion at ./logging.jl:320 [inlined]
│     [10] final_shred!(::Base.SecretBuffer) at ./secretbuffer.jl:169
│     [11] typeinf_ext(::Core.MethodInstance, ::Core.Compiler.Params) at ./compiler/typeinfer.jl:568
│     [12] typeinf_ext(::Core.MethodInstance, ::UInt64) at ./compiler/typeinfer.jl:604
│     [13] (::getfield(BinaryBuilder, Symbol("##323#327")){LibGit2.GitConfig,BinaryBuilder.WizardState,String,String,String,String,GitHub.OAuth2})(::LibGit2.GitRepo) at /home/mhildebr/.julia/dev/BinaryBuilder/src/wizard/deploy.jl:477
│     [14] with(::getfield(BinaryBuilder, Symbol("##323#327")){LibGit2.GitConfig,BinaryBuilder.WizardState,String,String,String,String,GitHub.OAuth2}, ::LibGit2.GitRepo) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/LibGit2/src/types.jl:1125
│     [15] #github_deploy#322(::LibGit2.GitConfig, ::Function, ::BinaryBuilder.WizardState) at /home/mhildebr/.julia/dev/BinaryBuilder/src/wizard/deploy.jl:455
│     [16] github_deploy at /home/mhildebr/.julia/dev/BinaryBuilder/src/wizard/deploy.jl:437 [inlined]
│     [17] step7(::BinaryBuilder.WizardState) at /home/mhildebr/.julia/dev/BinaryBuilder/src/wizard/deploy.jl:559
│     [18] run_wizard(::Nothing) at /home/mhildebr/.julia/dev/BinaryBuilder/src/Wizard.jl:101
│     [19] run_wizard() at /home/mhildebr/.julia/dev/BinaryBuilder/src/Wizard.jl:63
│     [20] top-level scope at none:0
│     [21] eval(::Module, ::Any) at ./boot.jl:319
│     [22] eval_user_input(::Any, ::REPL.REPLBackend) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/REPL/src/REPL.jl:85
│     [23] run_backend(::REPL.REPLBackend) at /home/mhildebr/.julia/packages/Revise/7ClGZ/src/Revise.jl:766
│     [24] (::getfield(Revise, Symbol("##58#60")){REPL.REPLBackend})() at ./task.jl:259
└ @ Base secretbuffer.jl:169
Exception handling log message: Asking travis to sync github and waiting until it knows about our new repo.
This may take a few seconds (or minutes, depending on Travis' mood)
Still Waiting...
Still Waiting...
Done waiting
Deployment Complete

Wizard Complete. Press any key to exit...

WizardState [done]
```

I don't have the time/experience to dig into what's happening, but hopefully it's a start?