### PR TITLE
Two small fixes for running Docker on Windows

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -329,7 +329,7 @@ function autobuild(dir::AbstractString,
                         repo = LibGit2.clone(src_url, src_path; isbare=true)
                     end
                 else
-                    if isfile(src_url)
+                    if BinaryProvider.safe_isfile(src_url)
                         # Immediately abspath() a src_url so we don't lose track of
                         # sources given to us with a relative path
                         src_path = abspath(src_url)

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -78,7 +78,7 @@ function DockerRunner(workspace_root::String;
     docker_cmd = `docker run --privileged `#--cap-add SYS_ADMIN`
 
     if cwd != nothing
-        docker_cmd = `$docker_cmd -w $(abspath(cwd))`
+        docker_cmd = `$docker_cmd -w /$(abspath(cwd))`
     end
 
     # Add in read-only mappings and read-write workspaces


### PR DESCRIPTION
With this, and `BINARYBUILDER=docker`, I can successfully run `BinaryBuilder.runshell` and could also run the SQLiteBuilder `build_tarballs.jl`.

More details in the commit messages.