### PR TITLE
Optional excluding of Products from supported_platforms()

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -400,7 +400,7 @@ represented here, it's probably because that platform is still considered "in be
 Platforms can be excluded from the list by specifying an array of platforms to `exclude`.
 i.e. `supported_platforms(exclude=[Windows(:i686),Windows(:x86_64)])`
 """
-function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=[])
+function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false)
     exclude_platforms!(exclude::Function, platforms) = filter(!exclude, platforms)
     function exclude_platforms!(exclude::Vector{<:Platform}, platforms)
     	for e in exclude

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -406,13 +406,8 @@ supported_platforms(exclude=islin)
 ```
 """
 function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false)
-    exclude_platforms!(exclude::Function, platforms) = filter(!exclude, platforms)
-    function exclude_platforms!(exclude::Vector{<:Platform}, platforms)
-    	for e in exclude
-    		filter!(x -> x != e, platforms)
-    	end
-    	return platforms
-    end
+    exclude_platforms!(platforms, exclude::Function) = filter(!exclude, platforms)
+    exclude_platforms!(platforms, exclude::Vector{<:Platform}) = filter!(!in(exclude), platforms)
     standard_platforms = [
         # glibc Linuces
         Linux(:i686),
@@ -435,7 +430,7 @@ function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->fal
         Windows(:i686),
         Windows(:x86_64),
     ]
-    return exclude_platforms!(exclude,standard_platforms)
+    return exclude_platforms!(standard_platforms,exclude)
 end
 
 function replace_gcc_version(p::Platform, gcc_version::Symbol)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -391,14 +391,19 @@ function choose_shards(p::Platform;
 end
 
 """
-    supported_platforms(;exclude::Vector=[])
+    supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false)
 
 Return the list of supported platforms as an array of `Platform`s.  These are the platforms we
 officially support building for, if you see a mapping in `get_shard_hash()` that isn't
 represented here, it's probably because that platform is still considered "in beta".
 
-Platforms can be excluded from the list by specifying an array of platforms to `exclude`.
-i.e. `supported_platforms(exclude=[Windows(:i686),Windows(:x86_64)])`
+Platforms can be excluded from the list by specifying an array of platforms to `exclude` i.e.
+`supported_platforms(exclude=[Windows(:i686),Windows(:x86_64)])`
+or a function that returns true for exclusions i.e.
+```
+islin(x) = typeof(x) == Linux
+supported_platforms(exclude=islin)
+```
 """
 function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=x->false)
     exclude_platforms!(exclude::Function, platforms) = filter(!exclude, platforms)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -400,10 +400,15 @@ represented here, it's probably because that platform is still considered "in be
 Platforms can be excluded from the list by specifying an array of platforms to `exclude`.
 i.e. `supported_platforms(exclude=[Windows(:i686),Windows(:x86_64)])`
 """
-function supported_platforms(;exclude::Vector=[])
-    platforms = [
-        #Standard Platforms
-
+function supported_platforms(;exclude::Union{Vector{<:Platform},Function}=[])
+    exclude_platforms!(exclude::Function, platforms) = filter(!exclude, platforms)
+    function exclude_platforms!(exclude::Vector{<:Platform}, platforms)
+    	for e in exclude
+    		filter!(x -> x != e, platforms)
+    	end
+    	return platforms
+    end
+    standard_platforms = [
         # glibc Linuces
         Linux(:i686),
         Linux(:x86_64),
@@ -425,10 +430,7 @@ function supported_platforms(;exclude::Vector=[])
         Windows(:i686),
         Windows(:x86_64),
     ]
-    for e in exclude
-        filter!(x->x !== e, platforms)
-    end
-    return platforms
+    return exclude_platforms!(exclude,standard_platforms)
 end
 
 function replace_gcc_version(p::Platform, gcc_version::Symbol)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -391,14 +391,19 @@ function choose_shards(p::Platform;
 end
 
 """
-    supported_platforms()
+    supported_platforms(;exclude::Vector=[])
 
 Return the list of supported platforms as an array of `Platform`s.  These are the platforms we
 officially support building for, if you see a mapping in `get_shard_hash()` that isn't
 represented here, it's probably because that platform is still considered "in beta".
+
+Platforms can be excluded from the list by specifying an array of platforms to `exclude`.
+i.e. `supported_platforms(exclude=[Windows(:i686),Windows(:x86_64)])`
 """
-function supported_platforms()
-    return [
+function supported_platforms(;exclude::Vector=[])
+    platforms = [
+        #Standard Platforms
+
         # glibc Linuces
         Linux(:i686),
         Linux(:x86_64),
@@ -420,6 +425,10 @@ function supported_platforms()
         Windows(:i686),
         Windows(:x86_64),
     ]
+    for e in exclude
+        filter!(x->x !== e, platforms)
+    end
+    return platforms
 end
 
 function replace_gcc_version(p::Platform, gcc_version::Symbol)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -19,6 +19,17 @@
     end
 end
 
+@testset "Supported Platforms" begin
+    all = supported_platforms()
+    opt_out_specific = supported_platforms(exclude=[Linux(:x86_64, libc=:glibc)])
+    # islin(x) = typeof(x) == Linux
+    # opt_out_fx = supported_platforms(exclude=BinaryBuilder.islin)
+
+    @test length(all) == length(opt_out_specific)+1
+    @test !any(opt_out_specific .== [Linux(:x86_64, libc=:glibc)])
+    # @test !any(opt_out_fx .== [Linux(:x86_64, libc=:glibc)])
+end
+
 @testset "Target properties" begin
     for t in ["i686-linux-gnu", "i686-w64-mingw32", "arm-linux-gnueabihf"]
         @test BinaryBuilder.target_nbits(t) == "32"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -22,12 +22,12 @@ end
 @testset "Supported Platforms" begin
     all = supported_platforms()
     opt_out_specific = supported_platforms(exclude=[Linux(:x86_64, libc=:glibc)])
-    # islin(x) = typeof(x) == Linux
-    # opt_out_fx = supported_platforms(exclude=BinaryBuilder.islin)
+    islin(x) = typeof(x) == Linux
+    opt_out_fx = supported_platforms(exclude=islin)
 
     @test length(all) == length(opt_out_specific)+1
     @test !any(opt_out_specific .== [Linux(:x86_64, libc=:glibc)])
-    # @test !any(opt_out_fx .== [Linux(:x86_64, libc=:glibc)])
+    @test !any(opt_out_fx .== [Linux(:x86_64, libc=:glibc)])
 end
 
 @testset "Target properties" begin

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -26,8 +26,8 @@ end
     opt_out_fx = supported_platforms(exclude=islin)
 
     @test length(all) == length(opt_out_specific)+1
-    @test !any(opt_out_specific .== [Linux(:x86_64, libc=:glibc)])
-    @test !any(opt_out_fx .== [Linux(:x86_64, libc=:glibc)])
+    @test any(opt_out_specific .== [Linux(:i686 , libc=:glibc)])
+    @test !any(opt_out_fx .== [Linux(:i686 , libc=:glibc)])
 end
 
 @testset "Target properties" begin


### PR DESCRIPTION
Provides exclusion within supported_platforms() to move to an opt-out style BinaryBuilder approach. 

```julia
>supported_platforms(exclude=[Windows(:i686),Windows(:x86_64)])
11-element Array{Platform,1}:
 Linux(:i686, libc=:glibc)                    
 Linux(:x86_64, libc=:glibc)                  
 Linux(:aarch64, libc=:glibc)                 
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf)
 Linux(:powerpc64le, libc=:glibc)             
 Linux(:i686, libc=:musl)                     
 Linux(:x86_64, libc=:musl)                   
 Linux(:aarch64, libc=:musl)                  
 Linux(:armv7l, libc=:musl, call_abi=:eabihf) 
 MacOS(:x86_64)                               
 FreeBSD(:x86_64)  
```

A couple of reasons why this might be nice:

1. The current approach tends to result in manual lists of platforms, with unsupported being left-off, meaning future additions to BB's supported_platforms require more effort to be added
2. With the _manual list & leave out excluded_ approach, it's not always  easy to figure out which platforms have been excluded (if they're not simply commented out) 

cc. @staticfloat, as discussed over in https://github.com/JuliaIO/OggBuilder/pull/2#issuecomment-496617866