### PR TITLE
Quote variables in compiler wrappers

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -70,10 +70,10 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
         #!/bin/sh
         # This compiler wrapper script brought into existence by `generate_compiler_wrappers()`
 
-        if [ -z \${SUPER_VERBOSE+x} ]; then
-            vrun() { \$@; }
+        if [ "x\${SUPER_VERBOSE}" = "x" ]; then
+            vrun() { "\$@"; }
         else
-            vrun() { echo -e "\\e[96m\$@\\e[0m" >&2; \$@; }
+            vrun() { echo -e "\\e[96m\$@\\e[0m" >&2; "\$@"; }
         fi
         """)
 


### PR DESCRIPTION
Also fix the test for `SUPER_VERBOSE`.