### PR TITLE
Check that we are shipping a license file and auto install licenses

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -396,6 +396,7 @@ function autobuild(dir::AbstractString,
                    ignore_audit_errors::Bool = true,
                    autofix::Bool = true,
                    code_dir::Union{String,Nothing} = nothing,
+                   require_license::Bool = true,
                    kwargs...)
     # If we're on CI and we're not verbose, schedule a task to output a "." every few seconds
     if (haskey(ENV, "TRAVIS") || haskey(ENV, "CI")) && !verbose
@@ -621,8 +622,9 @@ function autobuild(dir::AbstractString,
 
             # Run an audit of the prefix to ensure it is properly relocatable
             if !skip_audit
-                audit_result = audit(prefix; platform=platform,
-                                             verbose=verbose, autofix=autofix) 
+                audit_result = audit(prefix, src_name;
+                                     platform=platform, verbose=verbose,
+                                     autofix=autofix, require_license=require_license)
                 if !audit_result && !ignore_audit_errors
                     msg = replace("""
                     Audit failed for $(prefix.path).

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -591,7 +591,7 @@ function autobuild(dir::AbstractString,
 
             # If we're running as `bash`, then use the `DEBUG` and `ERR` traps
             if [ \$(basename \$0) = "bash" ]; then
-                trap "save_env" EXIT
+                trap "auto_install_license; save_env" EXIT
                 trap "RET=\$?; trap - DEBUG; echo Previous command exited with \$RET >&2; save_env; save_srcdir" INT TERM ERR
 
                 # Swap out srcdir from underneath our feet if we've got our `ERR`

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -112,7 +112,7 @@ function step3_audit(state::WizardState, platform::Platform, prefix::Prefix)
     printstyled(state.outs, "\n\t\t\tAnalyzing...\n\n", bold=true)
 
     audit(prefix; io=state.outs,
-        platform=platform, verbose=true, autofix=true)
+        platform=platform, verbose=true, autofix=true, require_license=false)
 
     println(state.outs)
 end
@@ -340,7 +340,7 @@ function step5_internal(state::WizardState, platform::Platform, message)
                 msg = "\n\t\t\tBuild complete. Analyzing...\n\n"
                 printstyled(state.outs, msg, bold=true)
 
-                audit(prefix; io=state.outs,
+                audit(prefix; io=state.outs, require_license=false,
                     platform=platform, verbose=true, autofix=true)
 
                 ok = isempty(match_files(state, prefix, platform, state.files))
@@ -527,7 +527,8 @@ function step5c(state::WizardState)
                 platform=platform,
                 verbose=false,
                 silent=true,
-                autofix=true
+                autofix=true,
+                require_license=false,
             )
 
             ok = isempty(match_files(

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -207,7 +207,8 @@ end
 """
     setup_workspace(build_path::String, src_paths::Vector,
                     src_hashes::Vector, platform::Platform,
-                    extra_env::Dict{String, String};
+                    src_name::AbstractString;
+                    extra_env::Dict{String, String} = Dict{String, String}(),
                     verbose::Bool = false, tee_stream::IO = stdout,
                     downloads_dir = nothing)
 


### PR DESCRIPTION
<s>This only checks in the `audit` that we're shipping the license file, but doesn't automatically install it if present in the source distribution.  I still have to find a good place where to hook in order to automatically install the license file :thinking: </s>

Ref #309.