### PR TITLE
WIP: Allow dlopen flags (e.g. RTLD_GLOBAL) for LibraryProduct

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -861,7 +861,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                     println(io, """
                         # Manually `dlopen()` this right now so that future invocations
                         # of `ccall` with its `SONAME` will find this path immediately.
-                        global $(vp)_handle = dlopen($(vp)_path)
+                        global $(vp)_handle = $(dlopen_str("$(vp)_path", p.dlopen_flags))
                         push!(LIBPATH_list, dirname($(vp)_path))
                     """)
                 elseif p isa ExecutableProduct

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -78,7 +78,8 @@ struct LibraryProduct <: Product
     libnames::Vector{String}
     variable_name::Symbol
     dir_paths::Vector{String}
-    dont_dlopen::Bool
+    try_dlopen::Bool
+    dlopen_flags::Vector{Symbol}
 
     """
         LibraryProduct(libnames, varname::Symbol)
@@ -99,9 +100,22 @@ struct LibraryProduct <: Product
     LibraryProduct(libname::AbstractString, varname, args...; kwargs...) = LibraryProduct([libname], varname, args...; kwargs...)
     function LibraryProduct(libnames::Vector{<:AbstractString}, varname::Symbol,
                             dir_paths::Vector{<:AbstractString}=String[];
-                            dont_dlopen::Bool=false)
+                            try_dlopen::Bool=true,
+                            dlopen_flags::Vector{Symbol}=Symbol[])
+        # catch invalid flags as early as possible
+        for flag in dlopen_flags
+            isdefined(Libdl, flag) || error("Libdl.$flag is not a valid flag")
+        end
         # If some other kind of AbstractString is passed in, convert it
-        return new([string(l) for l in libnames], varname, string.(dir_paths), dont_dlopen)
+        return new([string(l) for l in libnames], varname, string.(dir_paths), try_dlopen, dlopen_flags)
+    end
+end
+
+function dlopen_str(dl_path::String, dlopen_flags::Vector{Symbol}=Symbol[])
+    if length(dlopen_flags) > 0
+        return "Libdl.dlopen(\"$dl_path\", $(join(dlopen_flags, " | ")))"
+    else
+        return "Libdl.dlopen(\"$dl_path\")"
     end
 end
 
@@ -161,7 +175,7 @@ function locate(lp::LibraryProduct, prefix::Prefix; verbose::Bool = false,
                     end
 
                     # If it does, try to `dlopen()` it if the current platform is good
-                    if platforms_match(platform, platform_key_abi()) && !lp.dont_dlopen
+                    if platforms_match(platform, platform_key_abi()) && lp.try_dlopen
                         if isolate
                             # Isolated dlopen is a lot slower, but safer
                             if success(`$(Base.julia_cmd()) -e "import Libdl; Libdl.dlopen(\"$dl_path\")"`)


### PR DESCRIPTION
@staticfloat @giordano I haven't tested this extensively, but here's a sketch of what we were talking about earlier. 

Right now the flags are just used when generating the wrapper. Should they also be used in `locate(...)` and `Auditor.jl`?