### PR TITLE
In meson test, install binary and library and set rpath

### DIFF
--- a/test/build_tests/libfoo/meson.build
+++ b/test/build_tests/libfoo/meson.build
@@ -1,4 +1,18 @@
 project('foo', 'cpp')
 add_languages('c')
-libfoo = shared_library('foo', 'libfoo.c', version : '1.2.3', soversion : '0')
-executable('fooifier', 'fooifier.cpp', link_with : libfoo)
+
+libfoo = shared_library('foo', 'libfoo.c',
+			version : '1.2.3', soversion : '0',
+			install : true)
+
+# Set rpath directories for macOS and Linux, defaulting to nothing
+rpath_dir = ''
+if host_machine.system() == 'darwin'
+  rpath_dir = '@executable_path/../lib'
+elif host_machine.system() == 'linux'
+  rpath_dir = '$ORIGIN/../lib'
+endif
+
+executable('fooifier', 'fooifier.cpp',
+	   link_with : libfoo, install : true,
+	   install_rpath : rpath_dir)


### PR DESCRIPTION
building for macOS:
```
# otool -l ${bindir}/fooifier | grep -A2 RPATH
          cmd LC_RPATH
      cmdsize 40
         path @executable_path/../lib (offset 12)
```
building for Linux:
```
# x86_64-linux-gnu-objdump -p ${bindir}/fooifier | grep RPATH
  RPATH                $ORIGIN/../lib
```