### PR TITLE
Do not echo input when asking for a password in the wizard

### DIFF
--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -44,7 +44,7 @@ function obtain_token(; ins=stdin, outs=stdout, github_api=GitHub.DEFAULT_API)
 
     while true
         user = nonempty_line_prompt("Username", "GitHub username:", ins=ins, outs=outs)
-        password = nonempty_line_prompt("Password", "GitHub password:"; ins=ins, outs=outs)
+        password = nonempty_line_prompt("Password", "GitHub password:"; ins=ins, outs=outs, echo=false)
 
         # Shuffle this junk off to the GH API
         headers = Dict{String, String}("User-Agent"=>"BinaryBuilder-jl")


### PR DESCRIPTION
As [suggested by Keno](https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/465#issuecomment-549181497), I've looked into `Base.getpass`.  However, this _always_ appends "`: `" to the prompt, which doesn't play nicely with the custom prompt used by `BinaryBuilder.nonempty_line_prompt`.  Probably on Windows one could use `devnull` as output stream, but this wouldn't work on the other systems.  Thus, I've defined a function based on `Base.getpass` which never writes a prompt, as this is the current need in BB.  Maybe something like this should go into `Base.getpass`?

Fixes #465.