### PR TITLE
Fix `github_auth(allow_anonymous=true)` when `GITHUB_TOKEN` is not set

### DIFF
--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -18,8 +18,10 @@ function github_auth(;allow_anonymous::Bool=true)
         end
     end
 
-    # Also shove this into Registrator, so it uses the same token.
-    Registrator.CommentBot.CONFIG["github"] = Dict("token" => _github_auth[].token)
+    if !isa(_github_auth[], GitHub.AnonymousAuth)
+        # Also shove this into Registrator, so it uses the same token.
+        Registrator.CommentBot.CONFIG["github"] = Dict("token" => _github_auth[].token)
+    end
     return _github_auth[]
 end
 

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -248,3 +248,9 @@ end
     end
     @test state.step == :step3
 end
+
+@testset "GitHub - authentication" begin
+    withenv("GITHUB_TOKEN" => "") do
+        @test BinaryBuilder.github_auth(allow_anonymous=true) isa GitHub.AnonymousAuth
+    end
+end


### PR DESCRIPTION
Fix #471.