### PR TITLE
Give better error messages when JLL packages do not exist.

### DIFF
--- a/src/wizard/yggdrasil.jl
+++ b/src/wizard/yggdrasil.jl
@@ -18,6 +18,17 @@ function get_yggdrasil(;io::IO = stdout)
     return yggdrasil_dir
 end
 
+# We only want to update the registry once per run
+registry_updated = false
+function update_registry(ctx = Pkg.Types.Context())
+    if !registry_updated
+        Pkg.Registry.update(ctx, [
+            Pkg.Types.RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"),
+        ])
+        registry_updated
+    end
+end
+
 """
     yggdrasil_build_tarballs_path(name::String)
 

--- a/test/building.jl
+++ b/test/building.jl
@@ -196,3 +196,27 @@ shards_to_test = expand_cxxstring_abis(expand_gfortran_versions(shards_to_test))
         end
     end
 end
+
+@testset "Dependency Specification" begin
+    mktempdir() do build_path
+        @test_logs (:error, r"BadDependency_jll") (:error, r"WorseDependency_jll") begin
+            @test_throws ErrorException autobuild(
+                build_path,
+                "baddeps",
+                v"1.0.0",
+                # No sources
+                [],
+                "true",
+                [platform],
+                [ExecutableProduct("foo", :foo)],
+                # Three dependencies; one good, two bad
+                [
+                    "Zlib_jll",
+                    # We hope nobody will ever register something named this
+                    "BadDependency_jll",
+                    "WorseDependency_jll",
+                ]
+            )
+        end
+    end
+end

--- a/test/building.jl
+++ b/test/building.jl
@@ -199,7 +199,7 @@ end
 
 @testset "Dependency Specification" begin
     mktempdir() do build_path
-        @test_logs (:error, r"BadDependency_jll") (:error, r"WorseDependency_jll") begin
+        @test_logs (:error, r"BadDependency_jll") (:error, r"WorseDependency_jll") match_mode=:any begin
             @test_throws ErrorException autobuild(
                 build_path,
                 "baddeps",


### PR DESCRIPTION
Also update registry more automatically, but only once per session