### PR TITLE
Fixes to get JLL autoregistration working properly

### DIFF
--- a/docker_images/v1.3/Dockerfile
+++ b/docker_images/v1.3/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y xz-utils bzip2 sudo git
 
 # Set up default `git` username and email
 RUN git config --global user.name "jlbuild"
-RUN git config --global user.email "jlbuild@gmail.com"
+RUN git config --global user.email "juliabuildbot@gmail.com"
 
 # Install `ghr`
 RUN cd /usr/local/bin && \

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -218,7 +218,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
             # Open pull request against JuliaRegistries/General
             params = Dict(
                 "base" => "master",
-                "head" => reg_branch.branch,
+                "head" => "$(gh_username):$(reg_branch.branch)",
                 "maintainer_can_modify" => true,
                 "title" => "JLL Registration: $(deploy_repo)-v$(build_version)",
                 "body" => """

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -194,10 +194,13 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
             @info("Registering new wrapper code version $(build_version)...")
         end
 
-        # Register into our `General` fork
         if register
+            # Create fork (if it does not already exist)
+            fork = GitHub.create_fork("JuliaRegistries/General"; auth=gh_auth)
+
+            # Use Registrator to push up a new `General` branch with this JLL package registered within it
             cache = Registrator.RegEdit.RegistryCache(joinpath(Pkg.depots1(), "registries_binarybuilder"))
-            registry_url = "https://$(gh_username):$(gh_auth.token)@github.com/JuliaRegistries/General"
+            registry_url = "https://$(gh_username):$(gh_auth.token)@github.com/$(gh_username)/General"
             cache.registries[registry_url] = Base.UUID("23338594-aafe-5451-b93e-139f81909106")
             project = Pkg.Types.Project(build_project_dict(src_name, build_version, dependencies))
             reg_branch = Registrator.RegEdit.register(
@@ -212,7 +215,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
                 @error(reg_branch.metadata["error"])
             end
 
-            # Open pull request against General
+            # Open pull request against JuliaRegistries/General
             params = Dict(
                 "base" => "master",
                 "head" => reg_branch.branch,


### PR DESCRIPTION
Submit PRs from the proper fork, use the proper email for `@jlbuild` commits, etc...