### PR TITLE
Throw error when authenticating if input is closed and GITHUB_TOKEN is empty

### DIFF
--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -45,6 +45,12 @@ function obtain_token(; ins=stdin, outs=stdout, github_api=GitHub.DEFAULT_API)
     )
 
     while true
+        if !isopen(ins) || (!Sys.iswindows() && !isopen(stdin))
+            # We have to check also `stdin` because `_getpass` ignores `ins` and
+            # always uses `stdin` on Unices.
+            error("Cannot read from input stream")
+        end
+
         user = nonempty_line_prompt("Username", "GitHub username:", ins=ins, outs=outs)
         password = nonempty_line_prompt("Password", "GitHub password:"; ins=ins, outs=outs, echo=false)
 

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -252,5 +252,8 @@ end
 @testset "GitHub - authentication" begin
     withenv("GITHUB_TOKEN" => "") do
         @test BinaryBuilder.github_auth(allow_anonymous=true) isa GitHub.AnonymousAuth
+        input_stream = IOBuffer()
+        close(input_stream)
+        @test_throws ErrorException BinaryBuilder.obtain_token(ins=input_stream)
     end
 end


### PR DESCRIPTION
Ref #476.  See https://github.com/JuliaLang/julia/issues/33628#issuecomment-550030136