### PR TITLE
Add dependencies when running the wizard

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -20,6 +20,12 @@ git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.8"
 
+[[CSTParser]]
+deps = ["Tokenize"]
+git-tree-sha1 = "99dda94f5af21a4565dc2b97edf6a95485f116c3"
+uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+version = "1.0.0"
+
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
 git-tree-sha1 = "05916673a2627dd91b4969ff8ba6941bc85a960e"
@@ -34,9 +40,9 @@ version = "0.8.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
+git-tree-sha1 = "0caaa696071d6e7872ddf30e58ed6ec0b49954c4"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.2.0"
+version = "3.0.0"
 
 [[DataAPI]]
 git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
@@ -88,16 +94,16 @@ uuid = "8f6bce27-0656-5410-875b-07a5572985df"
 version = "0.1.5"
 
 [[GitHub]]
-deps = ["Base64", "Compat", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "Test"]
-git-tree-sha1 = "0224f2efcf87d783d64861e4a9ee08299164a569"
+deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets"]
+git-tree-sha1 = "477818ab174a14d4730b3d15ac8719dbc98555d2"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.1.1"
+version = "5.1.3"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "f1e1b417a34cf73a70cbed919915bf8f8bad1806"
+git-tree-sha1 = "5c49dab19938b119fe204fd7d7e8e174f4e9c68b"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.6"
+version = "0.8.8"
 
 [[Hiccup]]
 deps = ["MacroTools", "Test"]
@@ -121,10 +127,10 @@ uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
 [[JLD2]]
-deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Printf"]
-git-tree-sha1 = "343d1ec8ae7d57a608d79ef12e9a853cbb9acd96"
+deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
+git-tree-sha1 = "034eef3b23d75c67259bfd7ec2fa6ef786dd24a7"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.3"
+version = "0.1.6"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -158,10 +164,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
-deps = ["Compat", "DataStructures", "Test"]
-git-tree-sha1 = "82921f0e3bde6aebb8e524efc20f4042373c0c06"
+deps = ["CSTParser", "Compat", "DataStructures", "Test", "Tokenize"]
+git-tree-sha1 = "d6e9dedb8c92c3465575442da456aec15a89ff76"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.2"
+version = "0.5.1"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -228,9 +234,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[ProgressMeter]]
 deps = ["Distributed", "Printf"]
-git-tree-sha1 = "fab12b19f198dd148ca467ac4e4f12ecd0241819"
+git-tree-sha1 = "ea1f4fa0ff5e8b771bf130d87af5b7ef400760bd"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.1.0"
+version = "1.2.0"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
@@ -300,6 +306,11 @@ deps = ["Dates", "Test"]
 git-tree-sha1 = "43defcaf72b89b047f11b778cd83b71ac3e418b0"
 uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
 version = "0.2.0"
+
+[[Tokenize]]
+git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
+uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
+version = "0.5.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -27,5 +27,6 @@ VT100 = "7774df62-37c0-5c21-b34d-f6d7f98f54bc"
 ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
+JLD2 = ">= 0.1.6"
 Registrator = "1"
 julia = "1.3"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -513,21 +513,7 @@ function autobuild(dir::AbstractString,
     build_output_meta = Dict()
 
     # Resolve dependencies into PackageSpecs now, ensuring we have UUIDs for all deps
-    ctx = Pkg.Types.Context()
-    update_registry(ctx)
-    pkgspecify(name::String) = Pkg.Types.PackageSpec(;name=name)
-    pkgspecify(ps::Pkg.Types.PackageSpec) = ps
-    dependencies = pkgspecify.(dependencies)
-    Pkg.Types.registry_resolve!(ctx.env, dependencies)
-
-    # Ensure they all resolved properly
-    all_resolved = true
-    for dep in dependencies
-        if dep.uuid === nothing
-            @error("Unable to resolve $(dep.name)")
-            all_resolved = false
-        end
-    end
+    all_resolved, dependencies = resolve_jlls(dependencies)
     if !all_resolved
         error("Invalid dependency specifications!")
     end

--- a/src/auditor/compiler_abi.jl
+++ b/src/auditor/compiler_abi.jl
@@ -28,8 +28,7 @@ function check_libgfortran_version(oh::ObjectHandle, platform::Platform; verbose
         if isa(e, InterruptException)
             rethrow(e)
         end
-        @warn("$(path(oh)) could not be scanned for libgfortran dependency!")
-        @warn(e)
+        @warn "$(path(oh)) could not be scanned for libgfortran dependency!" exception=(e, catch_backtrace())
         return true
     end
 
@@ -88,8 +87,7 @@ function check_libstdcxx_version(oh::ObjectHandle, platform::Platform; verbose::
         if isa(e, InterruptException)
             rethrow(e)
         end
-        @warn("$(path(oh)) could not be scanned for libstdcxx dependency!")
-        @warn(e)
+        @warn "$(path(oh)) could not be scanned for libstdcxx dependency!" exception=(e, catch_backtrace())
         return true
     end
 
@@ -158,8 +156,7 @@ function detect_cxxstring_abi(oh::ObjectHandle, platform::Platform)
         if isa(e, InterruptException)
             rethrow(e)
         end
-        @warn("$(path(oh)) could not be scanned for cxx11 ABI!")
-        @warn(e)
+        @warn "$(path(oh)) could not be scanned for cxx11 ABI!" exception=(e, catch_backtrace())
     end
     return nothing
 end

--- a/src/auditor/compiler_abi.jl
+++ b/src/auditor/compiler_abi.jl
@@ -20,7 +20,7 @@ function detect_libgfortran_version(oh::ObjectHandle, platform::Platform)
     return detect_libgfortran_version(first(fortran_libs), platform)
 end
 
-function check_libgfortran_version(oh::ObjectHandle, platform::Platform; io::IO = stdout, verbose::Bool = false)
+function check_libgfortran_version(oh::ObjectHandle, platform::Platform; verbose::Bool = false)
     libgfortran_version = nothing
     try
         libgfortran_version = detect_libgfortran_version(oh, platform)
@@ -28,13 +28,13 @@ function check_libgfortran_version(oh::ObjectHandle, platform::Platform; io::IO 
         if isa(e, InterruptException)
             rethrow(e)
         end
-        warn(io, "$(path(oh)) could not be scanned for libgfortran dependency!")
-        warn(io, e)
+        @warn("$(path(oh)) could not be scanned for libgfortran dependency!")
+        @warn(e)
         return true
     end
 
     if verbose && libgfortran_version != nothing
-        info(io, "$(path(oh)) locks us to libgfortran v$(libgfortran_version)")
+        @info("$(path(oh)) locks us to libgfortran v$(libgfortran_version)")
     end
 
     if compiler_abi(platform).libgfortran_version === nothing && libgfortran_version != nothing
@@ -45,7 +45,7 @@ function check_libgfortran_version(oh::ObjectHandle, platform::Platform; io::IO 
         definition in your `build_tarballs.jl` file, add the line:
         """, '\n' => ' '))
         msg *= "\n\n    platforms = expand_gfortran_versions(platforms)"
-        warn(io, msg)
+        @warn(msg)
         return false
     end
     return true
@@ -79,7 +79,7 @@ function detect_libstdcxx_version(oh::ObjectHandle, platform::Platform)
     return maximum([VersionNumber(split(v, "_")[2]) for v in version_symbols])
 end
 
-function check_libstdcxx_version(oh::ObjectHandle, platform::Platform; io::IO = stdout, verbose::Bool = false)
+function check_libstdcxx_version(oh::ObjectHandle, platform::Platform; verbose::Bool = false)
     libstdcxx_version = nothing
 
     try
@@ -88,13 +88,13 @@ function check_libstdcxx_version(oh::ObjectHandle, platform::Platform; io::IO = 
         if isa(e, InterruptException)
             rethrow(e)
         end
-        warn(io, "$(path(oh)) could not be scanned for libstdcxx dependency!")
-        warn(io, e)
+        @warn("$(path(oh)) could not be scanned for libstdcxx dependency!")
+        @warn(e)
         return true
     end
 
     if verbose && libstdcxx_version != nothing
-        info(io, "$(path(oh)) locks us to libstdc++ v$(libstdcxx_version)+")
+        @info("$(path(oh)) locks us to libstdc++ v$(libstdcxx_version)+")
     end
 
     # This actually isn't critical, so we don't complain.  Yet.
@@ -135,7 +135,7 @@ std::string ABI it's using.  We do this by scanning the list of exported
 symbols, triggering off of instances of `St7__cxx11` or `_ZNSs` to give
 evidence toward a constraint on `cxx11`, `cxx03` or neither.
 """
-function detect_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = stdout)
+function detect_cxxstring_abi(oh::ObjectHandle, platform::Platform)
     try
         # First, if this object doesn't link against `libstdc++`, it's a `:cxxany`
         if !any(occursin("libstdc++", l) for l in ObjectFile.path.(DynamicLinks(oh)))
@@ -158,8 +158,8 @@ function detect_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = std
         if isa(e, InterruptException)
             rethrow(e)
         end
-        warn(io, "$(path(oh)) could not be scanned for cxx11 ABI!")
-        Base.display_error(io, e, [])
+        @warn("$(path(oh)) could not be scanned for cxx11 ABI!")
+        @warn(e)
     end
     return nothing
 end
@@ -168,7 +168,7 @@ end
 function check_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = stdout, verbose::Bool = false)
     # First, check the stdlibc++ string ABI to see if it is a superset of `platform`.  If it's
     # not, then we have a problem!
-    cxx_abi = detect_cxxstring_abi(oh, platform; io=io)
+    cxx_abi = detect_cxxstring_abi(oh, platform)
 
     # If no std::string symbols found, just exit out immediately
     if cxx_abi == nothing
@@ -187,7 +187,7 @@ function check_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = stdo
         definition in your `build_tarballs.jl` file, add the line:
         """, '\n' => ' '))
         msg *= "\n\n    products = expand_cxx_versions(products)"
-        warn(io, msg)
+        @warn(msg)
         return false
     end
 
@@ -198,7 +198,7 @@ function check_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = stdo
         indicates that the build system is somehow ignoring our choice of compiler, as we manually
         insert the correct compiler flags for this ABI choice!
         """, '\n' => ' '))
-        warn(io, msg)
+        @warn(msg)
         return false
     end
     return true

--- a/src/auditor/filesystems.jl
+++ b/src/auditor/filesystems.jl
@@ -1,4 +1,4 @@
-function check_case_sensitivity(prefix::Prefix; io::IO = stdout)
+function check_case_sensitivity(prefix::Prefix)
     all_ok = true
 
     function check_set(root, list)
@@ -6,7 +6,7 @@ function check_case_sensitivity(prefix::Prefix; io::IO = stdout)
         for f in list
             lf = lowercase(f)
             if lf in lowered
-                warn(io, "$(relpath(joinpath(root, f), prefix.path)) causes a case-sensitivity ambiguity!")
+                @warn("$(relpath(joinpath(root, f), prefix.path)) causes a case-sensitivity ambiguity!")
                 all_ok = false
             end
             push!(lowered, lf)
@@ -22,7 +22,7 @@ function check_case_sensitivity(prefix::Prefix; io::IO = stdout)
 end
 
 
-function check_absolute_paths(prefix::Prefix, all_files::Vector; io::IO = stdout, silent::Bool = false)
+function check_absolute_paths(prefix::Prefix, all_files::Vector; silent::Bool = false)
     # Finally, check for absolute paths in any files.  This is not a "fatal"
     # offense, as many files have absolute paths.  We want to know about it
     # though, so we'll still warn the user.
@@ -31,12 +31,12 @@ function check_absolute_paths(prefix::Prefix, all_files::Vector; io::IO = stdout
             file_contents = String(read(f))
             if occursin(prefix.path, file_contents)
                 if !silent
-                    warn(io, "$(relpath(f, prefix.path)) contains an absolute path")
+                    @warn("$(relpath(f, prefix.path)) contains an absolute path")
                 end
             end
         catch
             if !silent
-                warn(io, "Skipping abspath scanning of $(f), as we can't open it")
+                @warn("Skipping abspath scanning of $(f), as we can't open it")
             end
         end
     end

--- a/src/auditor/instruction_set.jl
+++ b/src/auditor/instruction_set.jl
@@ -1205,7 +1205,7 @@ if `verbose` is set to `true`.
 Note that this function only really makes sense for x86/x64 binaries.  Don't
 run this on armv7l, aarch64, ppc64le etc... binaries and expect it to work.
 """
-function analyze_instruction_set(oh::ObjectHandle, platform::Platform; verbose::Bool = false, io::IO = stdout)
+function analyze_instruction_set(oh::ObjectHandle, platform::Platform; verbose::Bool = false)
     # Get list of mnemonics
     mnemonics, counts = instruction_mnemonics(path(oh), platform)
 
@@ -1223,7 +1223,7 @@ function analyze_instruction_set(oh::ObjectHandle, platform::Platform; verbose::
             the proper instruction set internally.  Would have chosen
             $(min_isa), instead choosing $(new_min_isa).
             """, '\n' => ' ')
-            warn(io, strip(msg))
+            @warn(strip(msg))
         end
         return new_min_isa
     end

--- a/src/auditor/soname_matching.jl
+++ b/src/auditor/soname_matching.jl
@@ -6,8 +6,7 @@ function get_soname(path::AbstractString)
     try
         readmeta(get_soname, path)
     catch e
-        @warn("Could not probe $(path) for an SONAME!")
-        @warn(e)
+        @warn "Could not probe $(path) for an SONAME!" exception=(e, catch_backtrace())
         return nothing
     end
 end

--- a/src/auditor/soname_matching.jl
+++ b/src/auditor/soname_matching.jl
@@ -40,7 +40,7 @@ end
 
 
 function ensure_soname(prefix::Prefix, path::AbstractString, platform::Platform;
-                       verbose::Bool = false, autofix::Bool = false, io::IO = stdout)
+                       verbose::Bool = false, autofix::Bool = false)
     # Skip any kind of Windows platforms
     if platform isa Windows
         return true
@@ -81,19 +81,19 @@ function ensure_soname(prefix::Prefix, path::AbstractString, platform::Platform;
     end
 
     if !retval
-        warn(io, "Unable to set SONAME on $(rel_path)")
+        @warn("Unable to set SONAME on $(rel_path)")
         return false
     end
 
     # Read the SONAME back in and ensure it's set properly
     new_soname = get_soname(path)
     if new_soname != soname
-        warn(io, "Set SONAME on $(rel_path) to $(soname), but read back $(string(new_soname))!")
+        @warn("Set SONAME on $(rel_path) to $(soname), but read back $(string(new_soname))!")
         return false
     end
 
     if verbose
-        info(io, "Set SOANME of $(rel_path) to \"$(soname)\"")
+        @info("Set SOANME of $(rel_path) to \"$(soname)\"")
     end
 
     return true
@@ -107,8 +107,7 @@ SONAME (if it exists).  While this is almost always true in practice, it
 doesn't hurt to make doubly sure.
 """
 function symlink_soname_lib(path::AbstractString; verbose::Bool = false,
-                                                  autofix::Bool = false,
-                                                  io::IO = stdout)
+                                                  autofix::Bool = false)
     # If this library doesn't have an SONAME, then just quit out immediately
     soname = get_soname(path)
     if soname === nothing
@@ -120,12 +119,12 @@ function symlink_soname_lib(path::AbstractString; verbose::Bool = false,
     if !isfile(soname_path)
         if autofix
             if verbose
-                info(io, "Library $(soname) does not exist, creating...")
+                @info("Library $(soname) does not exist, creating...")
             end
             symlink(path, soname_path)
         else
             if verbose
-                info(io, "Library $(soname) does not exist, failing out...")
+                @info("Library $(soname) does not exist, failing out...")
             end
             return false
         end

--- a/src/auditor/symlink_translator.jl
+++ b/src/auditor/symlink_translator.jl
@@ -5,13 +5,13 @@ Walks through the root directory given within `root`, finding all symlinks that
 point to an absolute path within `root`, and rewriting them to be a relative
 symlink instead, increasing relocatability.
 """
-function translate_symlinks(root::AbstractString; verbose::Bool=false, io::IO = stdout)
+function translate_symlinks(root::AbstractString; verbose::Bool=false)
     for f in collect_files(root, islink)
         link_target = readlink(f)
         if isabspath(link_target) && startswith(link_target, "/workspace")
             new_link_target = relpath(link_target, replace(dirname(f), root => "/workspace/destdir"))
             if verbose
-                info(io, "Translating $f to point to $(new_link_target)")
+                @info("Translating $f to point to $(new_link_target)")
             end
             rm(f; force=true)
             symlink(new_link_target, f)

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,23 +1,3 @@
-## This is until we have a good replacement for `info(io, msg)` on 0.7+
-function info(io::IO, args...)
-    if io != stdout
-        printstyled(io, "Info: "; color=Base.info_color())
-        printstyled(io, args...; color=Base.info_color())
-        println(io)
-    else
-        @info(args)
-    end
-end
-function warn(io::IO, args...)
-    if io != stdout
-        printstyled(io, "Warning: "; color=Base.warn_color())
-        printstyled(io, args...; color=Base.warn_color())
-        println(io)
-    else
-        @warn(args)
-    end
-end
-
 function extract_kwargs(kwargs, keys)
     return (k => v for (k, v) in kwargs if k in keys)
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,13 +1,21 @@
 ## This is until we have a good replacement for `info(io, msg)` on 0.7+
 function info(io::IO, args...)
-    printstyled(io, "Info: "; color=Base.info_color())
-    printstyled(io, args...; color=Base.info_color())
-    println(io)
+    if io != stdout
+        printstyled(io, "Info: "; color=Base.info_color())
+        printstyled(io, args...; color=Base.info_color())
+        println(io)
+    else
+        @info(args)
+    end
 end
 function warn(io::IO, args...)
-    printstyled(io, "Warning: "; color=Base.warn_color())
-    printstyled(io, args...; color=Base.warn_color())
-    println(io)
+    if io != stdout
+        printstyled(io, "Warning: "; color=Base.warn_color())
+        printstyled(io, args...; color=Base.warn_color())
+        println(io)
+    else
+        @warn(args)
+    end
 end
 
 function extract_kwargs(kwargs, keys)

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -289,6 +289,14 @@ function step34(state::WizardState)
         state.source_hashes;
         verbose=false,
     )
+    ctx = Pkg.Types.Context()
+    update_registry(ctx)
+    pkgspecify(name::String) = Pkg.Types.PackageSpec(;name=name)
+    pkgspecify(ps::Pkg.Types.PackageSpec) = ps
+    dependencies = pkgspecify.(deepcopy(state.dependencies))
+    Pkg.Types.registry_resolve!(ctx.env, dependencies)
+
+    setup_dependencies(prefix, dependencies, platform)
     provide_hints(state, joinpath(prefix.path, "srcdir"))
 
     ur = preferred_runner()(

--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -339,7 +339,17 @@ function get_name_and_version(state::WizardState)
     end
 
     msg = "Enter a version number for this project:"
-    state.version = VersionNumber(nonempty_line_prompt("Version", msg; ins=state.ins, outs=state.outs))
+    while state.version === nothing
+        try
+            state.version = VersionNumber(nonempty_line_prompt("Version", msg; ins=state.ins, outs=state.outs))
+        catch e
+            if isa(e, ArgumentError)
+                println(state.outs, e.msg)
+                continue
+            end
+            rethrow(e)
+        end
+    end
 end
 
 """

--- a/src/wizard/state.jl
+++ b/src/wizard/state.jl
@@ -60,11 +60,6 @@ end
 function serializeable_fields(::WizardState)
     # We can't serialize TTY's, in general.
     bad_fields = [:ins, :outs, :github_api]
-
-    # JLD2 is angry at Pkg's BinaryPlatforms for some reason
-    # https://github.com/JuliaIO/JLD2.jl/issues/154
-    # Work around by serilializing `platforms` as triplets
-    append!(bad_fields, [:platforms, :failed_platforms, :visited_platforms, :validated_platforms])
     return [f for f in fieldnames(WizardState) if !(f in bad_fields)]
 end
 
@@ -76,10 +71,6 @@ function serialize(io, x::WizardState)
 
     # For unnecessarily complicated fields (such as `x.github_api`) store the internal data raw:
     io["github_api"] = string(x.github_api.endpoint)
-    io["platforms"] = triplet.(x.platforms)
-    io["failed_platforms"] = triplet.(x.failed_platforms)
-    io["visited_platforms"] = triplet.(x.visited_platforms)
-    io["validated_platforms"] = triplet.(x.validated_platforms)
 
     # For non-serializable fields (such as `x.ins` and `x.outs`) we just recreate them in unserialize().
 end

--- a/src/wizard/state.jl
+++ b/src/wizard/state.jl
@@ -34,7 +34,7 @@ necessary.  It also holds all necessary metadata such as input/output streams.
     source_urls::Union{Nothing, Vector{String}} = nothing
     source_files::Union{Nothing, Vector{String}} = nothing
     source_hashes::Union{Nothing, Vector{String}} = nothing
-    dependencies::Union{Nothing, Vector{String}} = nothing
+    dependencies::Union{Nothing, Vector} = nothing
 
     # Filled in by step 3
     history::Union{Nothing, String} = nothing

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -284,11 +284,11 @@ function resolve_jlls(dependencies::Vector; ctx = Pkg.Types.Context(), outs=stdo
     # Resolve, returning the newly-resolved dependencies
     dependencies = Pkg.Types.registry_resolve!(ctx.env, dependencies)
 
-    # But first, check to see if anythiny failed to resolve, and warn about it:
+    # But first, check to see if anything failed to resolve, and warn about it:
     all_resolved = true
     for dep in dependencies
         if dep.uuid === nothing
-            warn(outs, "Unable to resolve $(dep.name)")
+            @warn("Unable to resolve $(dep.name)")
             all_resolved = false
         end
     end

--- a/src/wizard/yggdrasil.jl
+++ b/src/wizard/yggdrasil.jl
@@ -1,16 +1,16 @@
 # Only update yggdrasil once
 yggdrasil_updated = false
-function get_yggdrasil(;io::IO = stdout)
+function get_yggdrasil()
     # TODO: Eventually, we want to use a Pkg cache to store Yggdrasil,
     # but since that doens't exist yet, we'll stick it into `deps`:
     yggdrasil_dir = abspath(joinpath(@__DIR__, "..", "..", "deps", "Yggdrasil"))
 
     if !isdir(yggdrasil_dir)
-        info(io, "Cloning bare Yggdrasil into deps/Yggdrasil...")
+        @info( "Cloning bare Yggdrasil into deps/Yggdrasil...")
         LibGit2.clone("https://github.com/JuliaPackaging/Yggdrasil.git", yggdrasil_dir; isbare=true)
     else
         if !yggdrasil_updated
-            info(io, "Updating bare Yggdrasil clone in deps/Yggdrasil...")
+            @info("Updating bare Yggdrasil clone in deps/Yggdrasil...")
             LibGit2.fetch(LibGit2.GitRepo(yggdrasil_dir))
         end
     end

--- a/src/wizard/yggdrasil.jl
+++ b/src/wizard/yggdrasil.jl
@@ -21,11 +21,12 @@ end
 # We only want to update the registry once per run
 registry_updated = false
 function update_registry(ctx = Pkg.Types.Context())
+    global registry_updated
     if !registry_updated
         Pkg.Registry.update(ctx, [
             Pkg.Types.RegistrySpec(uuid = "23338594-aafe-5451-b93e-139f81909106"),
         ])
-        registry_updated
+        registry_updated = true
     end
 end
 

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -165,7 +165,9 @@ end
         end
 
         # Test that `audit()` warns about an absolute path within the prefix
-        @test_warn "share/foo.conf" BinaryBuilder.audit(Prefix(build_path); verbose=true)
+        @test_logs (:warn, r"share/foo.conf contains an absolute path") match_mode=:any begin
+            BinaryBuilder.audit(Prefix(build_path); verbose=true)
+        end
     end
 end
 
@@ -237,7 +239,9 @@ end
 
             # If we audit the testdir, pretending that we're trying to build an ABI-agnostic
             # tarball, make sure it warns us about it.
-            @test_warn "links to libgfortran!" BinaryBuilder.audit(Prefix(testdir); platform=BinaryBuilder.abi_agnostic(platform), autofix=false)
+            @test_logs (:warn, r"links to libgfortran!") match_mode=:any begin
+                BinaryBuilder.audit(Prefix(testdir); platform=BinaryBuilder.abi_agnostic(platform), autofix=false)
+            end
         end
     end
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -166,10 +166,7 @@ end
 # Test that updating Yggdrasil works
 @testset "Yggdrasil" begin
     Core.eval(BinaryBuilder, :(yggdrasil_updated = false))
-    io = IOBuffer()
-    BinaryBuilder.get_yggdrasil(io=io)
-    seek(io, 0)
-    @test match(r"Yggdrasil", String(read(io))) != nothing
+    @test_logs (:info, r"Yggdrasil") BinaryBuilder.get_yggdrasil()
 end
 
 @testset "Tree symlinking" begin

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -218,7 +218,6 @@ end
         symlink("dir", joinpath(dstdir, "sym_dir2"))
 
         BinaryBuilder.unsymlink_tree(srcdir, dstdir)
-        run(`ls -la $(dstdir)`)
 
         @test isdir(dstdir)
         @test isdir(joinpath(dstdir, "dir"))

--- a/test/building.jl
+++ b/test/building.jl
@@ -199,7 +199,7 @@ end
 
 @testset "Dependency Specification" begin
     mktempdir() do build_path
-        @test_logs (:warning, r"BadDependency_jll") (:warning, r"WorseDependency_jll") match_mode=:any begin
+        @test_logs (:warn, r"BadDependency_jll") (:warn, r"WorseDependency_jll") match_mode=:any begin
             @test_throws ErrorException autobuild(
                 build_path,
                 "baddeps",

--- a/test/building.jl
+++ b/test/building.jl
@@ -199,7 +199,7 @@ end
 
 @testset "Dependency Specification" begin
     mktempdir() do build_path
-        @test_logs (:error, r"BadDependency_jll") (:error, r"WorseDependency_jll") match_mode=:any begin
+        @test_logs (:warning, r"BadDependency_jll") (:warning, r"WorseDependency_jll") match_mode=:any begin
             @test_throws ErrorException autobuild(
                 build_path,
                 "baddeps",

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -200,13 +200,6 @@ end
     """
     step3_test(state)
 
-
-
-    # These technically should wait until the terminal has been put into/come out
-    # of raw mode.  We could probably detect that, but good enough for now.
-    #wait_for_menu(pty) = sleep(0.1)
-    #wait_for_non_menu(pty) = sleep(1)
-
     # Step 3 failure path (no binary in destdir -> return to build)
     state = step3_state()
     with_wizard_output(state, BinaryBuilder.step34) do ins, outs

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -160,6 +160,7 @@ function step3_state()
     state.source_hashes = [libfoo_tarball_hash]
     state.name = "libfoo"
     state.version = v"1.0.0"
+    state.dependencies = String[]
 
     return state
 end
@@ -247,6 +248,26 @@ end
         call_response(ins, outs, "Return to build environment", "\e[B\r")
     end
     @test state.step == :step3
+
+
+    # Step 3 dependency download
+    state = step3_state()
+    state.dependencies = ["Zlib_jll"]
+    with_wizard_output(state, BinaryBuilder.step34) do ins, outs
+        call_response(ins, outs, "\${WORKSPACE}/srcdir", """
+        if [[ ! -f \${libdir}/libz.\${dlext} ]]; then
+            echo "ERROR: Could not find libz.\${dlext}" >&2
+            exit 1
+        fi
+        cd libfoo
+        make install
+        exit
+        """)
+        call_response(ins, outs, "Would you like to edit this script now?", "N")
+        call_response(ins, outs, "d=done, a=all", "ad"; newline=false)
+        call_response(ins, outs, "lib/libfoo.so:", "libfoo")
+        call_response(ins, outs, "bin/fooifier:", "fooifier")
+    end
 end
 
 @testset "GitHub - authentication" begin


### PR DESCRIPTION
On current master, binary dependencies were not added to the build environment when running the wizard, this should be fixed by this PR. I am not very familiar with the codebase, so maybe there are better ways to do this. 