### PR TITLE
Work around `go`'s penchant to mark directories as read-only

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -700,7 +700,9 @@ function autobuild(dir::AbstractString,
             products_info,
         )
 
-        # Destroy the workspace
+        # Destroy the workspace, taking care to make sure that we don't run into any
+        # permissions errors while we do so.
+        prepare_for_deletion(prefix.path)
         rm(prefix.path; recursive=true)
 
         # If the whole build_path is empty, then remove it too.  If it's not, it's probably

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -255,3 +255,13 @@ function with_logfile(f::Function, logfile::String)
         f(io)
     end
 end
+
+function prepare_for_deletion(prefix::String)
+    for (root, dirs, files) in walkdir(prefix)
+        for d in dirs
+            # Ensure that each directory is writable by by the owning user (should be us)
+            path = joinpath(root, d)
+            chmod(path, stat(path).mode | Base.Filesystem.S_IWUSR)
+        end
+    end
+end


### PR DESCRIPTION
This allows us to clean up the build prefix afterward