### PR TITLE
Print compiler versions before compiling

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -645,6 +645,8 @@ function autobuild(dir::AbstractString,
 
         dest_prefix = Prefix(joinpath(prefix.path, "destdir"))
         did_succeed = with_logfile(dest_prefix, "$(src_name).log") do io
+            # Let's start the presentations with BinaryBuilder.jl
+            write(io, "BinaryBuilder.jl version: $(get_bb_version())\n\n")
             # Get the list of compilers...
             compilers = extract_kwargs(kwargs, (:compilers,))
             # ...because we want to log all their versions.  However, we don't

--- a/src/BinaryBuilder.jl
+++ b/src/BinaryBuilder.jl
@@ -113,6 +113,18 @@ function __init__()
     end
 end
 
+function get_bb_version()
+    # Get BinaryBuilder.jl's version and git sha
+    version = Pkg.TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))["version"]
+    try
+        repo = LibGit2.GitRepo(dirname(@__DIR__))
+        gitsha = string(LibGit2.GitHash(LibGit2.GitCommit(repo, "HEAD")))
+        return "$(version)-$(gitsha)"
+    catch
+        return "$(version) (gitsha unavailable)"
+    end
+end
+
 """
     versioninfo()
 
@@ -122,16 +134,7 @@ function versioninfo()
     @info("Julia versioninfo(): ")
     InteractiveUtils.versioninfo()
 
-    # Get BinaryBuilder.jl's version and git sha
-    version = Pkg.TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))["version"]
-
-    try
-        repo = LibGit2.GitRepo(dirname(@__DIR__))
-        gitsha = string(LibGit2.GitHash(LibGit2.GitCommit(repo, "HEAD")))
-        @info("BinaryBuilder.jl version: $(version)-$(gitsha)")
-    catch
-        @info("BinaryBuilder.jl version: $(version) (gitsha unavailable)")
-    end
+    @info("BinaryBuilder.jl version: $(get_bb_version())")
 
     @static if Sys.isunix()
         @info("Kernel version: $(readchomp(`uname -r`))")


### PR DESCRIPTION
This is useful in order to keep the versions in the log file.

Maybe too many commands?  Do you suggest some other commands to log?