### PR TITLE
Fix error in wizard when no binary dependencies are used.

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -258,8 +258,8 @@ function obtain_binary_deps(state::WizardState)
     printstyled(state.outs, msg, bold=true)
 
     q = "Do you require any (binary) dependencies? "
+    state.dependencies = Any[]
     if yn_prompt(state, q, :n) == :y
-        state.dependencies = Any[]
         terminal = TTYTerminal("xterm", state.ins, state.outs, state.outs)
         while true
             jll_name = nonempty_line_prompt("package name", "Enter JLL package name:"; ins=state.ins, outs=state.outs)


### PR DESCRIPTION
E.g.
```
MethodError: no method matching (::BinaryBuilder.var"#pkgspecify#432")(::Nothing)
Closest candidates are:
  pkgspecify(::Pkg.Types.PackageSpec) at /home/fredrik/dev/BinaryBuilder/src/wizard/interactive_build.jl:295
  pkgspecify(::String) at /home/fredrik/dev/BinaryBuilder/src/wizard/interactive_build.jl:294
```