### PR TITLE
Fix Registrator compatibility to v1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,5 +28,5 @@ ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
 JLD2 = ">= 0.1.6"
-Registrator = "1"
+Registrator = "= 1.0.0"
 julia = "1.3"


### PR DESCRIPTION
Registrator v1.0.1 removed RegEdit, which breaks automatic JLL registration until BinaryBuilder is ported to use RegistryTools.