### PR TITLE
Don't overwrite PATH_list and LIBPATH_list

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1041,13 +1041,13 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                 # Initialize PATH and LIBPATH environment variable listings
                 global PATH_list, LIBPATH_list
                 # We first need to add to LIBPATH_list the libraries provided by Julia
-                LIBPATH_list = [joinpath(Sys.BINDIR, Base.LIBDIR, "julia"), joinpath(Sys.BINDIR, Base.LIBDIR)]
+                append!(LIBPATH_list, [joinpath(Sys.BINDIR, Base.LIBDIR, "julia"), joinpath(Sys.BINDIR, Base.LIBDIR)])
             """)
 
             if !isempty(dependencies)
                 println(io, """
-                    append!.(Ref(PATH_list), ($(join(["$(dep).PATH_list" for dep in dependencies], ", ")),))
-                    append!.(Ref(LIBPATH_list), ($(join(["$(dep).LIBPATH_list" for dep in dependencies], ", ")),))
+                    foreach(p -> append!(PATH_list, p), ($(join(["$(dep).PATH_list" for dep in dependencies], ", ")),))
+                    foreach(p -> append!(LIBPATH_list, p), ($(join(["$(dep).LIBPATH_list" for dep in dependencies], ", ")),))
                 """)
             end
 


### PR DESCRIPTION
Should fix
```
julia> using LuaCall
[ Info: Precompiling LuaCall [b19d909c-f536-5a7e-8424-a4fb7ce1e4d7]
WARNING: redefining constant LIBPATH_list
WARNING: redefining constant LIBPATH_list
```