### PR TITLE
Revert "build and push the JLL package on `--deploy`"

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -196,16 +196,16 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
     end
 
     if deploy
-        if verbose
-            @info("Committing and pushing $(src_name)_jll.jl wrapper code version $(build_version)...")
-        end
-
-        # The location the binaries will be available from
-        bin_path = "https://github.com/$(deploy_repo)/releases/download/$(tag)"
-        build_jll_package(src_name, build_version, code_dir, build_output_meta,
-                          dependencies, bin_path; verbose=verbose)
-        push_jll_package(src_name, build_version; code_dir=code_dir, deploy_repo=deploy_repo)
         if register
+            if verbose
+                @info("Committing and pushing $(src_name)_jll.jl wrapper code version $(build_version)...")
+            end
+
+            # The location the binaries will be available from
+            bin_path = "https://github.com/$(deploy_repo)/releases/download/$(tag)"
+            build_jll_package(src_name, build_version, code_dir, build_output_meta,
+                              dependencies, bin_path; verbose=verbose)
+            push_jll_package(src_name, build_version; code_dir=code_dir, deploy_repo=deploy_repo)
 
             if verbose
                 @info("Registering new wrapper code version $(build_version)...")


### PR DESCRIPTION
I think we need to quickly revert #537 because it's making it impossible to publish JLL packages built in parallel (as we do in Yggdrasil) and then figure out how to properly achieve what @ssfrr wanted to do there.

As an alternative, we can remove deploying from `build` job in Yggdrasil and move it to `register`, see https://github.com/JuliaPackaging/Yggdrasil/pull/274