### PR TITLE
Add small threshold for codecov success

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,10 @@
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        threshold: 1%


### PR DESCRIPTION
Not that the line
```yaml
comment: false
```
is working particularly well, even though [it does seem correct](https://docs.codecov.io/docs/pull-request-comments#section-disable-comment)...