### PR TITLE
Allow selection of compilers in the wizard

### DIFF
--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -319,8 +319,11 @@ function select_closest_version(preferred::VersionNumber, versions::Vector{Versi
     return versions[closest_idx]
 end
 
+const available_gcc_builds = [v"4.8.5", v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0"]
+const available_llvm_builds = [v"6.0.1", v"7.1.0", v"8.0.1", v"9.0.1"]
+
 function select_gcc_version(p::Platform,
-             GCC_builds::Vector{VersionNumber} = [v"4.8.5", v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0"],
+             GCC_builds::Vector{VersionNumber} = available_gcc_builds,
              preferred_gcc_version::VersionNumber = GCC_builds[1],
          )
     # Determine which GCC build we're going to match with this CompilerABI:
@@ -347,8 +350,8 @@ function choose_shards(p::Platform;
             compilers::Vector{Symbol} = [:c],
             rootfs_build::VersionNumber=v"2020.01.07",
             ps_build::VersionNumber=v"2020.01.15",
-            GCC_builds::Vector{VersionNumber}=[v"4.8.5", v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0"],
-            LLVM_builds::Vector{VersionNumber}=[v"6.0.1", v"7.1.0", v"8.0.1", v"9.0.1"],
+            GCC_builds::Vector{VersionNumber}=available_gcc_builds,
+            LLVM_builds::Vector{VersionNumber}=available_llvm_builds,
             Rust_build::VersionNumber=v"1.18.3",
             Go_build::VersionNumber=v"1.13",
             archive_type::Symbol = (use_squashfs ? :squashfs : :unpacked),

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -40,11 +40,19 @@ function print_build_tarballs(io::IO, state::WizardState)
     # Keyword arguments to `build_tarballs()`
     kwargs_vec = String[]
     if state.compilers != [:c] && length(state.compilers) >= 1
-        push!(kwargs_vec, "compilers = [$(join(map(x -> ":$(x)", state.compilers), ","))]")
+        push!(kwargs_vec, "compilers = [$(join(map(x -> ":$(x)", state.compilers), ", "))]")
+    end
+    # Default GCC version is the oldest one
+    if state.preferred_gcc_version != available_gcc_builds[1]
+        push!(kwargs_vec, "preferred_gcc_version = v\"$(state.preferred_gcc_version)\"")
+    end
+    # Default LLVM version is the latest one
+    if state.preferred_llvm_version != available_llvm_builds[end]
+        push!(kwargs_vec, "preferred_llvm_version = v\"$(state.preferred_llvm_version)\"")
     end
     kwargs = ""
     if length(kwargs_vec) >= 1
-        kwargs = "; " * join(kwargs_vec, ",")
+        kwargs = "; " * join(kwargs_vec, ", ")
     end
 
     print(io, """

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -37,6 +37,16 @@ function print_build_tarballs(io::IO, state::WizardState)
     psrepr(ps) = "\n    PackageSpec(name=\"$(ps.name)\", uuid=\"$(ps.uuid)\")"
     dependencies_string = join(map(psrepr, state.dependencies))
 
+    # Keyword arguments to `build_tarballs()`
+    kwargs_vec = String[]
+    if state.compilers != [:c] && length(state.compilers) >= 1
+        push!(kwargs_vec, "compilers = [$(join(map(x -> ":$(x)", state.compilers), ","))]")
+    end
+    kwargs = ""
+    if length(kwargs_vec) >= 1
+        kwargs = "; " * join(kwargs_vec, ",")
+    end
+
     print(io, """
     # Note that this script can accept some limited command-line arguments, run
     # `julia build_tarballs.jl --help` to see a usage message.
@@ -69,7 +79,7 @@ function print_build_tarballs(io::IO, state::WizardState)
     ]
 
     # Build the tarballs, and possibly a `build.jl` as well.
-    build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+    build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies$(kwargs))
     """)
 end
 

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -221,6 +221,7 @@ function step3_retry(state::WizardState)
         cwd="/workspace/srcdir",
         platform=platform,
         src_name=state.name,
+        compilers=state.compilers,
     )
     with_logfile(joinpath(build_path, "out.log")) do io
         run(ur, `/bin/bash -c $(state.history)`, io; verbose=true, tee_stream=state.outs)
@@ -309,6 +310,7 @@ function step34(state::WizardState)
         ],
         platform=platform,
         src_name=state.name,
+        compilers=state.compilers,
     )
     return step3_interactive(state, prefix, platform, ur, build_path, artifact_paths)
 end
@@ -346,6 +348,7 @@ function step5_internal(state::WizardState, platform::Platform)
                 cwd="/workspace/srcdir",
                 platform=platform,
                 src_name=state.name,
+                compilers=state.compilers,
             )
             with_logfile(joinpath(build_path, "out.log")) do io
                 run(ur, `/bin/bash -c $(state.history)`, io; verbose=true, tee_stream=state.outs)
@@ -412,6 +415,7 @@ function step5_internal(state::WizardState, platform::Platform)
                             cwd="/workspace/srcdir",
                             platform=platform,
                             src_name=state.name,
+                            compilers=state.compilers,
                         )
 
                         if interactive_build(state, prefix, ur, build_path;
@@ -538,6 +542,7 @@ function step5c(state::WizardState)
             cwd="/workspace/srcdir",
             platform=platform,
             src_name=state.name,
+            compilers=state.compilers,
         )
         with_logfile(joinpath(build_path, "out.log")) do io
             run(ur, `/bin/bash -c $(state.history)`, io; verbose=false, tee_stream=state.outs)

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -222,6 +222,8 @@ function step3_retry(state::WizardState)
         platform=platform,
         src_name=state.name,
         compilers=state.compilers,
+        preferred_gcc_version=state.preferred_gcc_version,
+        preferred_llvm_version=state.preferred_llvm_version,
     )
     with_logfile(joinpath(build_path, "out.log")) do io
         run(ur, `/bin/bash -c $(state.history)`, io; verbose=true, tee_stream=state.outs)
@@ -311,6 +313,8 @@ function step34(state::WizardState)
         platform=platform,
         src_name=state.name,
         compilers=state.compilers,
+        preferred_gcc_version=state.preferred_gcc_version,
+        preferred_llvm_version=state.preferred_llvm_version,
     )
     return step3_interactive(state, prefix, platform, ur, build_path, artifact_paths)
 end
@@ -349,6 +353,8 @@ function step5_internal(state::WizardState, platform::Platform)
                 platform=platform,
                 src_name=state.name,
                 compilers=state.compilers,
+                preferred_gcc_version=state.preferred_gcc_version,
+                preferred_llvm_version=state.preferred_llvm_version,
             )
             with_logfile(joinpath(build_path, "out.log")) do io
                 run(ur, `/bin/bash -c $(state.history)`, io; verbose=true, tee_stream=state.outs)
@@ -416,6 +422,8 @@ function step5_internal(state::WizardState, platform::Platform)
                             platform=platform,
                             src_name=state.name,
                             compilers=state.compilers,
+                            preferred_gcc_version=state.preferred_gcc_version,
+                            preferred_llvm_version=state.preferred_llvm_version,
                         )
 
                         if interactive_build(state, prefix, ur, build_path;
@@ -543,6 +551,8 @@ function step5c(state::WizardState)
             platform=platform,
             src_name=state.name,
             compilers=state.compilers,
+            preferred_gcc_version=state.preferred_gcc_version,
+            preferred_llvm_version=state.preferred_llvm_version,
         )
         with_logfile(joinpath(build_path, "out.log")) do io
             run(ur, `/bin/bash -c $(state.history)`, io; verbose=false, tee_stream=state.outs)

--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -381,6 +381,18 @@ function get_compilers(state::WizardState)
     end
 end
 
+function get_preferred_version(state::WizardState, compiler::AbstractString,
+                               available_versions=Vector{Integer})
+    terminal = TTYTerminal("xterm", state.ins, state.outs, state.outs)
+    version_selected = request(terminal, "Select the preferred $(compiler) version",
+                               RadioMenu(string.(available_versions)))
+    if compiler == "GCC"
+        state.preferred_gcc_version = available_versions[version_selected]
+    elseif compiler == "LLVM"
+        state.preferred_llvm_version = available_versions[version_selected]
+    end
+end
+
 """
     step2(state::WizardState)
 
@@ -392,7 +404,13 @@ function step2(state::WizardState)
     get_name_and_version(state)
     if yn_prompt(state, "Do you want to customize the set of compilers?", :n) == :y
         get_compilers(state)
+        get_preferred_version(state, "GCC", available_gcc_builds)
+        get_preferred_version(state, "LLVM", available_llvm_builds)
     else
         state.compilers = [:c]
+        # Default GCC version is the oldest one
+        state.preferred_gcc_version = available_gcc_builds[1]
+        # Default LLVM version is the latest one
+        state.preferred_llvm_version = available_llvm_builds[end]
     end
 end

--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -357,6 +357,30 @@ function get_name_and_version(state::WizardState)
     end
 end
 
+@enum Compilers C=1 Go Rust
+function get_compilers(state::WizardState)
+    while state.compilers === nothing
+        compiler_descriptions = Dict(C => "C/C++/Fortran", Go => "Go", Rust => "Rust")
+        compiler_symbols = Dict(Int(C) => :c, Int(Go) => :go, Int(Rust) => :rust)
+        terminal = TTYTerminal("xterm", state.ins, state.outs, state.outs)
+        result = nothing
+        while true
+            select_menu = MultiSelectMenu([compiler_descriptions[i] for i in instances(Compilers)])
+            select_menu.selected = Set([Int(C)])
+            result = request(terminal,
+                             "Select compilers for the project",
+                             select_menu
+                             )
+            if isempty(result)
+                println("Must select at least one platform")
+            else
+                break
+            end
+        end
+        state.compilers = map(c -> compiler_symbols[c], collect(result))
+    end
+end
+
 """
     step2(state::WizardState)
 
@@ -366,4 +390,9 @@ function step2(state::WizardState)
     obtain_source(state)
     obtain_binary_deps(state)
     get_name_and_version(state)
+    if yn_prompt(state, "Do you want to customize the set of compilers?", :n) == :y
+        get_compilers(state)
+    else
+        state.compilers = [:c]
+    end
 end

--- a/src/wizard/state.jl
+++ b/src/wizard/state.jl
@@ -36,6 +36,8 @@ necessary.  It also holds all necessary metadata such as input/output streams.
     source_hashes::Union{Nothing, Vector{String}} = nothing
     dependencies::Union{Nothing, Vector} = nothing
     compilers::Union{Nothing, Vector{Symbol}} = nothing
+    preferred_gcc_version::Union{Nothing, VersionNumber} = nothing
+    preferred_llvm_version::Union{Nothing, VersionNumber} = nothing
 
     # Filled in by step 3
     history::Union{Nothing, String} = nothing

--- a/src/wizard/state.jl
+++ b/src/wizard/state.jl
@@ -35,6 +35,7 @@ necessary.  It also holds all necessary metadata such as input/output streams.
     source_files::Union{Nothing, Vector{String}} = nothing
     source_hashes::Union{Nothing, Vector{String}} = nothing
     dependencies::Union{Nothing, Vector} = nothing
+    compilers::Union{Nothing, Vector{Symbol}} = nothing
 
     # Filled in by step 3
     history::Union{Nothing, String} = nothing

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -105,6 +105,10 @@ end
         # Test bad version number detection
         call_response(ins, outs, "Enter a version number", "parse me, I dare you")
         call_response(ins, outs, "Enter a version number", "1.0.0")
+
+        # Compiler
+        call_response(ins, outs, "Do you want to customize the set of compilers?", "Y")
+        call_response(ins, outs, "Select compilers for the project", "d")
     end
     # Check that the state is modified appropriately
     @test state.source_urls == ["http://127.0.0.1:14444/a/source.tar.gz"]
@@ -122,6 +126,8 @@ end
 
         call_response(ins, outs, "Enter a name for this project", "libfoo")
         call_response(ins, outs, "Enter a version number", "1.0.0")
+
+        call_response(ins, outs, "Do you want to customize the set of compilers?", "N")
     end
     # Check that the state is modified appropriately
     @test state.source_urls == [
@@ -143,6 +149,8 @@ end
 
         call_response(ins, outs, "Enter a name for this project", "broken_symlink")
         call_response(ins, outs, "Enter a version number", "1.0.0")
+
+        call_response(ins, outs, "Do you want to customize the set of compilers?", "N")
     end
 
     # Test failure to resolve a dependency
@@ -164,6 +172,8 @@ end
 
         call_response(ins, outs, "Enter a name for this project", "check_deps")
         call_response(ins, outs, "Enter a version number", "1.0.0")
+
+        call_response(ins, outs, "Do you want to customize the set of compilers?", "N")
     end
     @test length(state.dependencies) == 2
     @test any([d.name == "ghr_jll" for d in state.dependencies])
@@ -190,6 +200,7 @@ function step3_state()
     state.name = "libfoo"
     state.version = v"1.0.0"
     state.dependencies = typeof(Pkg.PackageSpec(name="dummy"))[]
+    state.compilers = [:c]
 
     return state
 end

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -108,12 +108,16 @@ end
 
         # Compiler
         call_response(ins, outs, "Do you want to customize the set of compilers?", "Y")
-        call_response(ins, outs, "Select compilers for the project", "d")
+        call_response(ins, outs, "Select compilers for the project", "ad")
+        call_response(ins, outs, "Select the preferred GCC version", "\r")
+        call_response(ins, outs, "Select the preferred LLVM version", "\e[B\e[B\e[B\r")
     end
     # Check that the state is modified appropriately
     @test state.source_urls == ["http://127.0.0.1:14444/a/source.tar.gz"]
     @test state.source_hashes == [libfoo_tarball_hash]
-
+    @test Set(state.compilers) == Set([:c, :rust, :go])
+    @test state.preferred_gcc_version == BinaryBuilder.available_gcc_builds[1]
+    @test state.preferred_llvm_version == BinaryBuilder.available_llvm_builds[4]
 
     # Test two tar.gz download
     state = step2_state()
@@ -201,6 +205,8 @@ function step3_state()
     state.version = v"1.0.0"
     state.dependencies = typeof(Pkg.PackageSpec(name="dummy"))[]
     state.compilers = [:c]
+    state.preferred_gcc_version = BinaryBuilder.available_gcc_builds[1]
+    state.preferred_llvm_version = BinaryBuilder.available_llvm_builds[end]
 
     return state
 end


### PR DESCRIPTION
I'm not very familiar with wizard code.  The wizard now it's failing for me during audit of the second platform tested, quite possible I did something wrong in `src/wizard/interactive_build.jl`.

Maybe this could be the base for an advanced option to activate on request, that lets the user choose other compiler-related stuff, like the preferred GCC and LLVM.