### PR TITLE
Define `BINARYBUILDER_NPROC` to override `${nproc}`

### DIFF
--- a/docs/src/build_tips.md
+++ b/docs/src/build_tips.md
@@ -109,7 +109,7 @@ You can include local files like patches very easily by placing them within a `b
 
 ## Automatic environment variables
 
-The following environment variables are automatically set in the build environment and should be used to build the project.  Occasionally, you may need to tweak them (e.g., when [using GCC on macOS and FreeBSD](@ref)).
+The following environment variables are automatically set in the build environment and should be used to build the project.  Occasionally, you may need to tweak them (e.g., when [Using GCC on macOS and FreeBSD](@ref)).
 
 * `CC`: the C cross compiler
 * `CXX`: the C++ cross compiler

--- a/docs/src/environment_variables.md
+++ b/docs/src/environment_variables.md
@@ -11,3 +11,5 @@
 * `BINARYBUILDER_ALLOW_ECRYPTFS`: When set to `true`, this allows the mounting of rootfs/shard/workspace directories from within encrypted mounts.  This is disabled by default, as at the time of writing, this triggers kernel bugs.  To avoid these kernel bugs on a system where e.g. the home directory has been encrypted, set the `BINARYBUILDER_ROOTFS_DIR` and `BINARYBUILDER_SHARDS_DIR` environment variables to a path outside of the encrypted home directory.
 
 * `BINARYBUILDER_USE_CCACHE`: When set to `true`, this causes a `/root/.ccache` volume to be mounted within the build environment, and for the `CC`, `CXX` and `FC` environment variables to have `ccache` prepended to them.  This can significantly accelerate rebuilds of the same package on the same host.  Note that `ccache` will, by default, store 5G of cached data.
+
+* `BINARYBUILDER_NPROC`: Overrides the value of the environment variable `${nproc}` set during a build, see [Automatic environment variables](@ref).

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -441,7 +441,7 @@ function platform_envs(platform::Platform, src_name::AbstractString; host_platfo
         "target" => target,
         "rust_target" => map_rust_target(platform),
         "rust_host" => map_rust_target(rust_host), # use glibc since musl is broken. :( https://github.com/rust-lang/rust/issues/59302
-        "nproc" => "$(Sys.CPU_THREADS)",
+        "nproc" => "$(get(ENV, "BINARYBUILDER_NPROC", Sys.CPU_THREADS))",
         "nbits" => string(nbits(platform)),
         "proc_family" => string(proc_family(platform)),
         "dlext" => dlext(platform),


### PR DESCRIPTION
```
julia> BinaryBuilder.runshell(Linux(:x86_64));
sandbox:${WORKSPACE} # echo ${nproc} 
8
sandbox:${WORKSPACE} # logout

julia> ENV["BINARYBUILDER_NPROCS"] = "5"
"5"

julia> BinaryBuilder.runshell(Linux(:x86_64));
sandbox:${WORKSPACE} # echo ${nproc} 
5
```
however there is no validation of the input