### PR TITLE
Dev BinaryBuilder in Dockerfile, instead of adding master

### DIFF
--- a/docker_images/v1.3/Dockerfile
+++ b/docker_images/v1.3/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /storage/dev_packages
 
 # Install BinaryBuilder
 ADD https://api.github.com/repos/JuliaPackaging/BinaryBuilder.jl/git/refs/heads/master /usr/share/binarybuilder_version.json
-RUN julia -e 'using Pkg; Pkg.add(PackageSpec(name="BinaryBuilder", rev="master"))'
+RUN julia -e 'using Pkg; Pkg.develop(PackageSpec(name="BinaryBuilder"))'
 RUN julia -e 'using Pkg; Pkg.API.precompile();'
 
 # Force artifact storage into /storage/artifacts


### PR DESCRIPTION
When adding master `BinaryBuilderversioninfo()` doesn’t provide useful insights
about the exact version used.