### PR TITLE
Run tests with docker on Julia 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
         - BINARYBUILDER_RUNNER=unprivileged
 
     # Add a job that uses the docker builder with unpacked shards
-    - julia: 1.3
+    - julia: 1.3.0
       env:
         - BINARYBUILDER_RUNNER=docker
 


### PR DESCRIPTION
Tests with `BINARYBUILDER_RUNNER=docker` are failing because of #593.  This pull request uses Julia 1.3.0 in this case, which at least works around the issue.  When #593 is fixed, this change can be reverted.