### PR TITLE
Setup dependencies that match the GCC ABI of the compiler

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -629,6 +629,8 @@ function autobuild(dir::AbstractString,
         build_path = joinpath(dir, "build", triplet(platform))
         mkpath(build_path)
 
+        shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+
         prefix = setup_workspace(
             build_path,
             src_paths,
@@ -648,6 +650,7 @@ function autobuild(dir::AbstractString,
             ],
             compiler_wrapper_dir = joinpath(prefix, "compiler_wrappers"),
             src_name = src_name,
+            shards = shards,
             extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:compilers,:allow_unsafe_flags))...,
         )
 

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -72,6 +72,7 @@ function DockerRunner(workspace_root::String;
                       verbose::Bool = false,
                       compiler_wrapper_path::String = mktempdir(),
                       src_name::AbstractString = "",
+                      shards = nothing,
                       kwargs...)
     global use_ccache
 
@@ -97,8 +98,10 @@ function DockerRunner(workspace_root::String;
         push!(workspaces, "binarybuilder_ccache" => "/root/.ccache")
     end
 
-    # Choose the shards we're going to mount
-    shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+    if isnothing(shards)
+        # Choose the shards we're going to mount
+        shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+    end
 
     # Import docker image
     import_docker_image(shards[1], workspace_root; verbose=verbose)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -349,6 +349,7 @@ const available_llvm_builds = [LLVMBuild(v"6.0.1"),
 
 """
     gcc_version(cabi::CompilerABI, GCC_builds::Vector{GCCBuild})
+
 Returns the closest matching GCC version number for the given CompilerABI
 representing a particular platofrm, from the given set of options.  If no match
 is found, returns an empty list.  This method assumes that `cabi` represents a
@@ -418,8 +419,11 @@ function choose_shards(p::Platform;
             Go_build::VersionNumber=v"1.13",
             archive_type::Symbol = (use_squashfs ? :squashfs : :unpacked),
             bootstrap_list::Vector{Symbol} = bootstrap_list,
-            # We prefer the oldest GCC version by default
+            # Because GCC has lots of compatibility issues, we always default to
+            # the earliest version possible.
             preferred_gcc_version::VersionNumber = getversion(GCC_builds[1]),
+            # Because LLVM doesn't have compatibilty issues, we always default
+            # to the newest version possible.
             preferred_llvm_version::VersionNumber = getversion(LLVM_builds[end]),
         )
 

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -532,6 +532,59 @@ function expand_cxxstring_abis(ps::Vector{<:Platform})
 end
 
 """
+    preferred_libgfortran_version(platform::Platform, shard::CompilerShard)
+
+Return the libgfortran version preferred by the given platform or GCCBootstrap shard.
+"""
+function preferred_libgfortran_version(platform::Platform, shard::CompilerShard)
+    # Some input validation
+    if shard.name != "GCCBootstrap"
+        error("Shard must be `GCCBootstrap`")
+    end
+    if shard.target.arch != platform.arch || shard.target.libc != platform.libc
+        error("Incompatible platform and shard target")
+    end
+
+    if compiler_abi(platform).libgfortran_version != nothing
+        # Here we can't use `shard.target` because the shard always has the
+        # target as ABI-agnostic, thus we have also to ask for the platform.
+        return compiler_abi(platform).libgfortran_version
+    elseif shard.version < v"7"
+        return v"3"
+    elseif v"7" <= shard.version < v"8"
+        return v"4"
+    else
+        return v"5"
+    end
+end
+
+"""
+    preferred_cxxstring_abi(platform::Platform, shard::CompilerShard)
+
+Return the C++ string ABI preferred by the given platform or GCCBootstrap shard.
+"""
+function preferred_cxxstring_abi(platform::Platform, shard::CompilerShard)
+    # Some input validation
+    if shard.name != "GCCBootstrap"
+        error("Shard must be `GCCBootstrap`")
+    end
+    if shard.target.arch != platform.arch || shard.target.libc != platform.libc
+        error("Incompatible platform and shard target")
+    end
+
+    if compiler_abi(platform).cxxstring_abi != nothing
+        # Here we can't use `shard.target` because the shard always has the
+        # target as ABI-agnostic, thus we have also to ask for the platform.
+        return compiler_abi(platform).cxxstring_abi
+    elseif shard.version < v"5"
+        return :cxx03
+    else
+        return :cxx11
+    end
+end
+
+
+"""
     download_all_shards(; verbose::Bool=false)
 
 Helper function to download all shards/helper binaries so that no matter what

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -327,7 +327,7 @@ function select_gcc_version(p::Platform,
              preferred_gcc_version::VersionNumber = GCC_builds[1],
          )
     # Determine which GCC build we're going to match with this CompilerABI:
-    GCC_builds = Pkg.BinaryPlatforms.gcc_version(compiler_abi(p), GCC_builds)
+    GCC_builds = gcc_version(compiler_abi(p), GCC_builds)
 
     if isempty(GCC_builds)
         error("Impossible CompilerABI constraints $(cabi)!")
@@ -583,6 +583,76 @@ function preferred_cxxstring_abi(platform::Platform, shard::CompilerShard)
     end
 end
 
+"""
+    gcc_version(cabi::CompilerABI, GCC_versions::Vector{VersionNumber};
+                                   rounding_mode=:platform)
+Returns the closest matching GCC version number for the given CompilerABI
+representing a particular platofrm, from the given set of options.  If no match
+is found, returns an empty list.  This method assumes that `cabi` represents a
+platform that binaries will be run on, and thus versions are always rounded
+down; e.g. if the platform supports a `libstdc++` version that corresponds to
+`GCC 5.1.0`, but the only GCC versions available to be picked from are `4.8.5`
+and `5.2.0`, it will return `4.8.5`, as binaries compiled with that version
+will run on this platform, whereas binaries compiled with `5.2.0` may not.
+"""
+function gcc_version(cabi::CompilerABI, GCC_versions::Vector{VersionNumber})
+    filt_gcc_majver(versions...) = filter(v -> v.major in versions, GCC_versions)
+
+    # First, filter by libgfortran version.
+    #  libgfortran3 -> GCC 4.X, 5.X, 6.X
+    #  libgfortran4 -> GCC 7.x
+    #  libgfortran5 -> GCC 8.X, 9.X
+    if cabi.libgfortran_version !== nothing
+        if cabi.libgfortran_version.major == 3
+            GCC_versions = filt_gcc_majver(4,5,6)
+        elseif cabi.libgfortran_version.major == 4
+            GCC_versions = filt_gcc_majver(7)
+        elseif cabi.libgfortran_version.major == 5
+            GCC_versions = filt_gcc_majver(8, 9)
+        end
+    end
+
+    # Next, filter by libstdc++ GLIBCXX symbol version.  Note that this
+    # mapping is conservative; it is often the case that we return a
+    # version that is slightly lower than what is actually installed on
+    # a system.
+    if cabi.libstdcxx_version !== nothing
+        cxxvp = cabi.libstdcxx_version.patch
+        # Is this platform so old that nothing is supported?
+        if cxxvp < 19
+            return VersionNumber[]
+
+        # Is this platform in a nominal range?
+        elseif cxxvp < 27
+            # See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
+            # for the whole list, as well as many other interesting factoids.
+            mapping = Dict(
+                19 => v"4.8.5",
+                20 => v"4.9.0",
+                21 => v"5.1.0",
+                22 => v"6.1.0",
+                23 => v"7.1.0",
+                24 => v"7.2.0",
+                25 => v"8.0.0",
+                26 => v"9.0.0",
+            )
+            GCC_versions = filter(v -> v <= mapping[cxxvp], GCC_versions)
+
+        # The implicit `else` here is that no filtering occurs; this platform
+        # has such broad support that any C++ code compiled will run on it.
+        end
+    end
+
+    # Finally, enforce cxxstring_abi guidelines.  It is possible to build
+    # :cxx03 binaries on GCC 5+, (although increasingly rare) so the only
+    # filtering we do is that if the platform is explicitly :cxx11, we
+    # disallow running on < GCC 5.
+    if cabi.cxxstring_abi !== nothing && cabi.cxxstring_abi === :cxx11
+        GCC_versions = filter(v -> v >= v"5", GCC_versions)
+    end
+
+    return GCC_versions
+end
 
 """
     download_all_shards(; verbose::Bool=false)

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -319,8 +319,34 @@ function select_closest_version(preferred::VersionNumber, versions::Vector{Versi
     return versions[closest_idx]
 end
 
-const available_gcc_builds = [v"4.8.5", v"5.2.0", v"6.1.0", v"7.1.0", v"8.1.0", v"9.1.0"]
-const available_llvm_builds = [v"6.0.1", v"7.1.0", v"8.0.1", v"9.0.1"]
+abstract type CompilerBuild end
+
+struct GCCBuild <: CompilerBuild
+    version::VersionNumber
+    abi::CompilerABI
+end
+GCCBuild(v::VersionNumber) = GCCBuild(v, CompilerABI())
+
+struct LLVMBuild <: CompilerBuild
+    version::VersionNumber
+    abi::CompilerABI
+end
+LLVMBuild(v::VersionNumber) = LLVMBuild(v, CompilerABI())
+
+getversion(c::CompilerBuild) = c.version
+getabi(c::CompilerBuild) = c.abi
+
+const available_gcc_builds = [GCCBuild(v"4.8.5", CompilerABI(libgfortran_version = v"3", libstdcxx_version = v"3.4.19", cxxstring_abi = :cxx03)),
+                              GCCBuild(v"5.2.0", CompilerABI(libgfortran_version = v"3", libstdcxx_version = v"3.4.21", cxxstring_abi = :cxx11)),
+                              GCCBuild(v"6.1.0", CompilerABI(libgfortran_version = v"3", libstdcxx_version = v"3.4.22", cxxstring_abi = :cxx11)),
+                              GCCBuild(v"7.1.0", CompilerABI(libgfortran_version = v"4", libstdcxx_version = v"3.4.23", cxxstring_abi = :cxx11)),
+                              GCCBuild(v"8.1.0", CompilerABI(libgfortran_version = v"5", libstdcxx_version = v"3.4.25", cxxstring_abi = :cxx11)),
+                              GCCBuild(v"9.1.0", CompilerABI(libgfortran_version = v"5", libstdcxx_version = v"3.4.26", cxxstring_abi = :cxx11))]
+const available_llvm_builds = [LLVMBuild(v"6.0.1"),
+                               LLVMBuild(v"7.1.0"),
+                               LLVMBuild(v"8.0.1"),
+                               LLVMBuild(v"9.0.1")]
+
 
 function select_gcc_version(p::Platform,
              GCC_builds::Vector{VersionNumber} = available_gcc_builds,

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -27,6 +27,7 @@ function UserNSRunner(workspace_root::String;
                       verbose::Bool = false,
                       compiler_wrapper_path::String = mktempdir(),
                       src_name::AbstractString = "",
+                      shards = nothing,
                       kwargs...)
     global use_ccache, use_squashfs, runner_override
 
@@ -55,8 +56,10 @@ function UserNSRunner(workspace_root::String;
         push!(workspaces, ccache_dir() => "/root/.ccache")
     end
 
-    # Choose the shards we're going to mount
-    shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+    if isnothing(shards)
+        # Choose the shards we're going to mount
+        shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+    end
 	
     # Construct sandbox command to look at the location it'll be mounted under
     mpath = mount_path(shards[1], workspace_root)

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -43,11 +43,11 @@ function print_build_tarballs(io::IO, state::WizardState)
         push!(kwargs_vec, "compilers = [$(join(map(x -> ":$(x)", state.compilers), ", "))]")
     end
     # Default GCC version is the oldest one
-    if state.preferred_gcc_version != available_gcc_builds[1]
+    if state.preferred_gcc_version != getversion(available_gcc_builds[1])
         push!(kwargs_vec, "preferred_gcc_version = v\"$(state.preferred_gcc_version)\"")
     end
     # Default LLVM version is the latest one
-    if state.preferred_llvm_version != available_llvm_builds[end]
+    if state.preferred_llvm_version != getversion(available_llvm_builds[end])
         push!(kwargs_vec, "preferred_llvm_version = v\"$(state.preferred_llvm_version)\"")
     end
     kwargs = ""

--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -404,13 +404,13 @@ function step2(state::WizardState)
     get_name_and_version(state)
     if yn_prompt(state, "Do you want to customize the set of compilers?", :n) == :y
         get_compilers(state)
-        get_preferred_version(state, "GCC", available_gcc_builds)
-        get_preferred_version(state, "LLVM", available_llvm_builds)
+        get_preferred_version(state, "GCC", getversion.(available_gcc_builds))
+        get_preferred_version(state, "LLVM", getversion.(available_llvm_builds))
     else
         state.compilers = [:c]
         # Default GCC version is the oldest one
-        state.preferred_gcc_version = available_gcc_builds[1]
+        state.preferred_gcc_version = getversion(available_gcc_builds[1])
         # Default LLVM version is the latest one
-        state.preferred_llvm_version = available_llvm_builds[end]
+        state.preferred_llvm_version = getversion(available_llvm_builds[end])
     end
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -310,7 +310,7 @@ end
     @test all(x->x.uuid !== nothing, resolved_deps)
 end
 
-@testset "Rootfs" begin
+@testset "Compiler Shards" begin
     @test_throws ErrorException CompilerShard("GCCBootstrap", v"4", Linux(:x86_64), :invalid_archive_type)
 
     @testset "GCC ABI matching" begin

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -2,6 +2,8 @@ using BinaryBuilder
 using GitHub, Test, VT100, Sockets, HTTP, SHA
 import Pkg
 
+import BinaryBuilder: available_gcc_builds, available_llvm_builds, getversion
+
 function with_wizard_output(f::Function, state, step_func::Function)
     # Create fake terminal to communicate with BinaryBuilder over
     pty = VT100.create_pty(false)
@@ -116,8 +118,8 @@ end
     @test state.source_urls == ["http://127.0.0.1:14444/a/source.tar.gz"]
     @test state.source_hashes == [libfoo_tarball_hash]
     @test Set(state.compilers) == Set([:c, :rust, :go])
-    @test state.preferred_gcc_version == BinaryBuilder.available_gcc_builds[1]
-    @test state.preferred_llvm_version == BinaryBuilder.available_llvm_builds[4]
+    @test state.preferred_gcc_version == getversion(available_gcc_builds[1])
+    @test state.preferred_llvm_version == getversion(BinaryBuilder.available_llvm_builds[4])
 
     # Test two tar.gz download
     state = step2_state()
@@ -205,8 +207,8 @@ function step3_state()
     state.version = v"1.0.0"
     state.dependencies = typeof(Pkg.PackageSpec(name="dummy"))[]
     state.compilers = [:c]
-    state.preferred_gcc_version = BinaryBuilder.available_gcc_builds[1]
-    state.preferred_llvm_version = BinaryBuilder.available_llvm_builds[end]
+    state.preferred_gcc_version = getversion(available_gcc_builds[1])
+    state.preferred_llvm_version = getversion(available_llvm_builds[end])
 
     return state
 end

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -119,7 +119,7 @@ end
     @test state.source_hashes == [libfoo_tarball_hash]
     @test Set(state.compilers) == Set([:c, :rust, :go])
     @test state.preferred_gcc_version == getversion(available_gcc_builds[1])
-    @test state.preferred_llvm_version == getversion(BinaryBuilder.available_llvm_builds[4])
+    @test state.preferred_llvm_version == getversion(BinaryBuilder.available_llvm_builds[end])
 
     # Test two tar.gz download
     state = step2_state()


### PR DESCRIPTION
This should solve the issue we had in https://github.com/JuliaPackaging/Yggdrasil/pull/369 where the build environment had libgfortran3, but a dependency (namely OpenBLAS) was downloaded in its libgfortran5 flavour.

I tested this PR locally with https://github.com/JuliaPackaging/Yggdrasil/pull/378.