### PR TITLE
Make audit actually show error message when it can't open a library

### DIFF
--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -124,8 +124,8 @@ function audit(prefix::Prefix, src_name::AbstractString = "";
                 end
             """
             try
-                p = open(`$(Base.julia_cmd()) -e $dlopen_cmd`)
-                wait(p)
+                p = run(`$(Base.julia_cmd()) -e $dlopen_cmd`,
+                        verbose ? (devnull, stdout, stderr) : (devnull, devnull, devnull))
                 if p.exitcode != 0
                     throw("Invalid exit code!")
                 end


### PR DESCRIPTION
This has always struck me, as you don't have a clue why a library can't be dlopened.  This is particularly important when a build is failing remotely, but not locally, like in https://github.com/JuliaPackaging/Yggdrasil/pull/324 and https://github.com/JuliaPackaging/Yggdrasil/pull/336.