### PR TITLE
Stop compilers from using known unsafe options

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -642,7 +642,7 @@ function autobuild(dir::AbstractString,
             ],
             compiler_wrapper_dir = joinpath(prefix, "compiler_wrappers"),
             src_name = src_name,
-            extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:compilers))...,
+            extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:compilers,:allow_unsafe_flags))...,
         )
 
         # Set up some bash traps

--- a/src/DockerRunner.jl
+++ b/src/DockerRunner.jl
@@ -83,7 +83,7 @@ function DockerRunner(workspace_root::String;
     envs = merge(platform_envs(platform, src_name; verbose=verbose), extra_env)
 
     # JIT out some compiler wrappers, add it to our mounts
-    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,))...)
+    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
 
     # the workspace_root is always a workspace, and we always mount it first

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -41,7 +41,7 @@ function UserNSRunner(workspace_root::String;
     envs = merge(platform_envs(platform, src_name; verbose=verbose), extra_env)
 
     # JIT out some compiler wrappers, add it to our mounts
-    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,))...)
+    generate_compiler_wrappers!(platform; bin_path=compiler_wrapper_path, extract_kwargs(kwargs, (:compilers,:allow_unsafe_flags))...)
     push!(workspaces, compiler_wrapper_path => "/opt/bin")
 
     # the workspace_root is always a workspace, and we always mount it first


### PR DESCRIPTION
For context, it was reported in
https://github.com/JuliaCI/BaseBenchmarks.jl/issues/253 that dlopening a library
compiled with `-Ofast` caused the denormal mode to be changed.

This PR disallows using compiler flags that are known to cause troubles.