### PR TITLE
Add audit pass to check OS/ABI for FreeBSD libraries

### DIFF
--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -6,6 +6,7 @@ include("auditor/symlink_translator.jl")
 include("auditor/compiler_abi.jl")
 include("auditor/soname_matching.jl")
 include("auditor/filesystems.jl")
+include("auditor/extra_checks.jl")
 
 # AUDITOR TODO LIST:
 #
@@ -82,6 +83,7 @@ function audit(prefix::Prefix, src_name::AbstractString = "";
                     all_ok &= check_dynamic_linkage(oh, prefix, bin_files;
                                                     platform=platform, silent=silent,
                                                     verbose=verbose, autofix=autofix)
+                    all_ok &= check_os_abi(oh, platform, verbose = verbose)
                 end
             end
         catch e

--- a/src/auditor/extra_checks.jl
+++ b/src/auditor/extra_checks.jl
@@ -1,0 +1,16 @@
+# This file contains some extra checks that don't fall into the other
+# categories, for example because they're very platform-specific.
+
+check_os_abi(::ObjectHandle, ::Platform, rest...; verbose::Bool = false, kwargs...) = true
+
+function check_os_abi(oh::ELFHandle, ::FreeBSD, rest...; verbose::Bool = false, kwargs...)
+    if oh.ei.osabi != 0x09
+        # The dynamic loader should not have problems in this case, but the
+        # linker may not appreciate.  Let the user know about this.
+        if verbose
+            @warn "OS/ABI is not set to FreeBSD (0x09) in the file header, this may be an issue at linking time"
+        end
+        return false
+    end
+    return true
+end


### PR DESCRIPTION
This is not a real issue for the dynamic loader, which seems to be happy to open a library with the OS/ABI bit not set to FreeBSD, but we found already a few times that a FreeBSD library with this bit set to 0x00 (System V) upsets our linker, which thinks that this is a foreign library.

I created a new file `auditor/extra_checks.jl` because I think there might be other platform-specific or not very well classified checks in the future.