### PR TITLE
Add keyword argument `lazy_artifacts` for `build_tarballs()`

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,3 +1,3 @@
 function extract_kwargs(kwargs, keys)
-    return (k => v for (k, v) in kwargs if k in keys)
+    return (k => v for (k, v) in pairs(kwargs) if k in keys)
 end


### PR DESCRIPTION
This allows generating an `Artifacts.toml` marking the tarballs for lazy download.  See for example [this `Artifact.toml`](https://github.com/giordano/HelloWorldC/blob/master/Artifacts.toml).

I think one possible use case is to make lazy JLL packagess with large tarballs and to be used optionally in Julia packages, like MKL_jll.

Still to do:

* [x] figure out what's wrong with `extract_kwargs(kwargs, (:lazy_artifact,))...,` :confused: 
* [x] figure out the the necessary changes, if any, to deploy lazy packages on Yggdrasil ([this call](https://github.com/JuliaPackaging/Yggdrasil/blob/d2f473a974d3c130f8bdcb8f33614cf6164f06d6/.ci/register_package.jl#L32) to `BinaryBuilder.rebuild_jll_packages` needs to get the value of `lazy_artifact`, from where?)