### PR TITLE
Fix dead `cxxstring_abi` code paths

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -289,7 +289,7 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
     # Default these tools to the "target tool" versions, will override later
     for tool in (:ar, :as, :cpp, :ld, :nm, :libtool, :objcopy, :objdump, :otool,
                  :ranlib, :readelf, :strip, :install_name_tool, :dlltool, :windres, :winmc, :lipo)
-        @eval $(tool)(io::IO, p::Platform) = $(wrapper)(io, string("/opt/", triplet(abi_agnostic($p)), "/bin/", triplet(abi_agnostic($p)), "-", $(string(tool))); allow_ccache=false)
+        @eval $(tool)(io::IO, p::Platform) = $(wrapper)(io, string("/opt/", triplet(abi_agnostic(p)), "/bin/", triplet(abi_agnostic(p)), "-", $(string(tool))); allow_ccache=false)
     end
  
     # c++filt is hard to write in symbols

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -298,7 +298,7 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
 
     # Overrides for macOS binutils because Apple is always so "special"
     for tool in (:ar, :ranlib, :dsymutil)
-        @eval $(tool)(io::IO, p::MacOS) = $(wrapper)(io, string("/opt/", aatriplet(p), "/bin/llvm-", $tool))
+        @eval $(tool)(io::IO, p::MacOS) = $(wrapper)(io, string("/opt/", triplet(abi_agnostic(p)), "/bin/llvm-", $tool))
     end
     # macOS doesn't have a readelf; default to using the host version
     @eval readelf(io::IO, p::MacOS) = readelf(io, $(host_platform))

--- a/src/UserNSRunner.jl
+++ b/src/UserNSRunner.jl
@@ -155,7 +155,7 @@ function Base.run(ur::UserNSRunner, cmd, logger::IO = stdout; verbose::Bool = fa
     return did_succeed
 end
 
-const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, IOStream}
+const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, IOStream, IOBuffer}
 function run_interactive(ur::UserNSRunner, cmd::Cmd; stdin = nothing, stdout = nothing, stderr = nothing, verbose::Bool = false)
     global prompted_userns_run_privileged
     if runner_override == "privileged" && !prompted_userns_run_privileged

--- a/src/auditor/compiler_abi.jl
+++ b/src/auditor/compiler_abi.jl
@@ -115,7 +115,7 @@ function cppfilt(symbol_names::Vector, platform::Platform)
     for name in symbol_names
         println(input, name)
     end
-    seek(input, 0)
+    seekstart(input)
 
     output = IOBuffer()
     mktemp() do t, io

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -1,5 +1,22 @@
 # Tests for our auditing infrastructure
 
+@testset "Auditor - cppfilt" begin
+    # We take some known x86_64-linux-gnu symbols and pass them through c++filt
+    mangled_symbol_names = [
+        "_ZNKSt7__cxx1110_List_baseIiSaIiEE13_M_node_countEv",
+        "_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6lengthEv@@GLIBCXX_3.4.21",
+        "_Z10my_listlenNSt7__cxx114listIiSaIiEEE",
+        "_ZNKSt7__cxx114listIiSaIiEE4sizeEv",
+    ]
+    unmangled_symbol_names = BinaryBuilder.cppfilt(mangled_symbol_names, Linux(:x86_64))
+    @test all(unmangled_symbol_names .== [
+        "std::__cxx11::_List_base<int, std::allocator<int> >::_M_node_count() const",
+        "std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::length() const@@GLIBCXX_3.4.21",
+        "my_listlen(std::__cxx11::list<int, std::allocator<int> >)",
+        "std::__cxx11::list<int, std::allocator<int> >::size() const",
+    ])
+end
+
 @testset "Auditor - ISA tests" begin
     mktempdir() do build_path
         products = Product[

--- a/test/build_tests/cxxstringabi_tests/Makefile
+++ b/test/build_tests/cxxstringabi_tests/Makefile
@@ -1,0 +1,14 @@
+all: libcxxstringabi_test.$(dlext)
+
+$(libdir):
+	mkdir -p $(libdir)
+
+libcxxstringabi_test.$(dlext): lib.cc Makefile
+	$(CXX) $(CFLAGS) -fPIC $< -g -o $@ $(LDFLAGS) -shared
+install: $(libdir) libcxxstringabi_test.$(dlext)
+	cp libcxxstringabi_test.$(dlext) $(libdir)/
+
+clean:
+	rm -rf libcxxstringabi_test.so libcxxstringabi_test.dll libcxxstringabi_test.dylib libcxxstringabi_test.dylib.dSYM
+
+.SUFFIXES:

--- a/test/build_tests/cxxstringabi_tests/lib.cc
+++ b/test/build_tests/cxxstringabi_tests/lib.cc
@@ -1,0 +1,14 @@
+#include <string>
+#include <list>
+
+std::string my_name() {
+    return std::string("Bob The Binary Builder");
+}
+
+int my_strlen(std::string str) {
+    return str.length();
+}
+
+int my_listlen(std::list<int> x) {
+    return x.size();
+}


### PR DESCRIPTION
We were accidentally stripping out ABI information from our platform
objects while generating compiler wrappers, resulting in `cxxstring_abi`
settings being ignored.  In order to ensure that this does not happen
again, we've added some more tests ensuring that when we ask to build a
`cxx11` library, we actually get what we asked for.

Also, the `cppfilt()` function wasn't working at all because I forgot to `seek(input, 0)` before sending it into the `run_interactive()`.