### PR TITLE
Expose the full triplet to the build script.

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -471,6 +471,7 @@ function platform_envs(platform::Platform, src_name::AbstractString; host_platfo
     mapping = Dict(
         # Platform information (we save a `bb_target` because sometimes `target` gets
         # overwritten in `./configure`, and we want tools like `uname` to still see it)
+        "bb_platform" => triplet(platform),
         "bb_target" => target,
         "target" => target,
         "rust_target" => map_rust_target(platform),


### PR DESCRIPTION
I need this (target + ABI) to download the LLVMBuilder output:
```
script = raw"""
wget -nv https://github.com/staticfloat/LLVMBuilder/releases/download/v8.0.1+4/LLVM.asserts.v8.0.1.${triplet}.tar.gz
...
"""
```

EDIT: I ended up adding the download as a regular `sources` entry, so I don't strictly need this anymore.