### PR TITLE
Layman integration with AZP logging

### DIFF
--- a/src/auditor/compiler_abi.jl
+++ b/src/auditor/compiler_abi.jl
@@ -28,6 +28,8 @@ function check_libgfortran_version(oh::ObjectHandle, platform::Platform; verbose
         if isa(e, InterruptException)
             rethrow(e)
         end
+        audit_warn("$(path(oh)) could not be scanned for libgfortran dependency!",
+                   @__FILE__, @__LINE__; show_long = false)
         @warn "$(path(oh)) could not be scanned for libgfortran dependency!" exception=(e, catch_backtrace())
         return true
     end
@@ -44,7 +46,7 @@ function check_libgfortran_version(oh::ObjectHandle, platform::Platform; verbose
         definition in your `build_tarballs.jl` file, add the line:
         """, '\n' => ' '))
         msg *= "\n\n    platforms = expand_gfortran_versions(platforms)"
-        @warn(msg)
+        audit_warn(msg, @__FILE__, @__LINE__)
         return false
     end
     return true
@@ -87,6 +89,8 @@ function check_libstdcxx_version(oh::ObjectHandle, platform::Platform; verbose::
         if isa(e, InterruptException)
             rethrow(e)
         end
+        audit_warn("$(path(oh)) could not be scanned for libstdcxx dependency!",
+                   @__FILE__, @__LINE__; show_long = false)
         @warn "$(path(oh)) could not be scanned for libstdcxx dependency!" exception=(e, catch_backtrace())
         return true
     end
@@ -158,6 +162,8 @@ function detect_cxxstring_abi(oh::ObjectHandle, platform::Platform)
         if isa(e, InterruptException)
             rethrow(e)
         end
+        audit_warn("$(path(oh)) could not be scanned for cxx11 ABI!",
+                   @__FILE__, @__LINE__; show_long = false)
         @warn "$(path(oh)) could not be scanned for cxx11 ABI!" exception=(e, catch_backtrace())
     end
     return nothing
@@ -186,7 +192,7 @@ function check_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = stdo
         definition in your `build_tarballs.jl` file, add the line:
         """, '\n' => ' '))
         msg *= "\n\n    platforms = expand_cxxstring_abis(platforms)"
-        @warn(msg)
+        audit_warn("Need to expand C++ string ABIs", msg, @__FILE__, @__LINE__)
         return false
     end
 
@@ -197,7 +203,7 @@ function check_cxxstring_abi(oh::ObjectHandle, platform::Platform; io::IO = stdo
         indicates that the build system is somehow ignoring our choice of compiler, as we manually
         insert the correct compiler flags for this ABI choice!
         """, '\n' => ' '))
-        @warn(msg)
+        audit_warn("Requested C++ string ABI has been ignored", msg, @__FILE__, @__LINE__)
         return false
     end
     return true

--- a/src/auditor/extra_checks.jl
+++ b/src/auditor/extra_checks.jl
@@ -8,7 +8,8 @@ function check_os_abi(oh::ELFHandle, ::FreeBSD, rest...; verbose::Bool = false, 
         # The dynamic loader should not have problems in this case, but the
         # linker may not appreciate.  Let the user know about this.
         if verbose
-            @warn "OS/ABI is not set to FreeBSD (0x09) in the file header, this may be an issue at linking time"
+            audit_warn("OS/ABI is not set to FreeBSD (0x09) in the file header, this may be an issue at linking time",
+                       @__FILE__, @__LINE__)
         end
         return false
     end

--- a/src/auditor/filesystems.jl
+++ b/src/auditor/filesystems.jl
@@ -6,7 +6,8 @@ function check_case_sensitivity(prefix::Prefix)
         for f in list
             lf = lowercase(f)
             if lf in lowered
-                @warn("$(relpath(joinpath(root, f), prefix.path)) causes a case-sensitivity ambiguity!")
+                audit_warn("$(relpath(joinpath(root, f), prefix.path)) causes a case-sensitivity ambiguity!",
+                           @__FILE__, @__LINE__)
                 all_ok = false
             end
             push!(lowered, lf)
@@ -31,12 +32,12 @@ function check_absolute_paths(prefix::Prefix, all_files::Vector; silent::Bool = 
             file_contents = String(read(f))
             if occursin(prefix.path, file_contents)
                 if !silent
-                    @warn("$(relpath(f, prefix.path)) contains an absolute path")
+                    audit_warn("$(relpath(f, prefix.path)) contains an absolute path", @__FILE__, @__LINE__)
                 end
             end
         catch
             if !silent
-                @warn("Skipping abspath scanning of $(f), as we can't open it")
+                audit_warn("Skipping abspath scanning of $(f), as we can't open it", @__FILE__, @__LINE__)
             end
         end
     end

--- a/src/auditor/instruction_set.jl
+++ b/src/auditor/instruction_set.jl
@@ -1223,7 +1223,8 @@ function analyze_instruction_set(oh::ObjectHandle, platform::Platform; verbose::
             the proper instruction set internally.  Would have chosen
             $(min_isa), instead choosing $(new_min_isa).
             """, '\n' => ' ')
-            @warn(strip(msg))
+            audit_warn("Refusing to analyze for minum instruction set", strip(msg),
+                       @__FILE__, @__LINE__)
         end
         return new_min_isa
     end

--- a/src/auditor/soname_matching.jl
+++ b/src/auditor/soname_matching.jl
@@ -6,6 +6,8 @@ function get_soname(path::AbstractString)
     try
         readmeta(get_soname, path)
     catch e
+        audit_warn("Could not probe $(path) for an SONAME!",
+                   @__FILE__, @__LINE__; show_long = false)
         @warn "Could not probe $(path) for an SONAME!" exception=(e, catch_backtrace())
         return nothing
     end
@@ -80,14 +82,15 @@ function ensure_soname(prefix::Prefix, path::AbstractString, platform::Platform;
     end
 
     if !retval
-        @warn("Unable to set SONAME on $(rel_path)")
+        audit_warn("Unable to set SONAME on $(rel_path)", @__FILE__, @__LINE__)
         return false
     end
 
     # Read the SONAME back in and ensure it's set properly
     new_soname = get_soname(path)
     if new_soname != soname
-        @warn("Set SONAME on $(rel_path) to $(soname), but read back $(string(new_soname))!")
+        audit_warn("Set SONAME on $(rel_path) to $(soname), but read back $(string(new_soname))!",
+                   @__FILE__, @__LINE__)
         return false
     end
 


### PR DESCRIPTION
This is a less than ideal implementation of #513.  I believe a long-term solution would need to properly use Julia's logging features (for this reason #513 will remain open), but before we get there we can try with this one to see how it goes, if we like it, and what we need to improve for a more stable implementation.

This gives you an idea of how it appears:
![image](https://user-images.githubusercontent.com/765740/72855881-e4dfbc00-3cb0-11ea-93ec-bfa44a6a6a45.png)
The warning is a clickable link to the message printed here:
![image](https://user-images.githubusercontent.com/765740/72855934-0b9df280-3cb1-11ea-85e7-c297c7c9c0fa.png)
