### PR TITLE
Reverse the order of LLVM compilers proposed in the wizard

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -384,8 +384,8 @@ end
 function get_preferred_version(state::WizardState, compiler::AbstractString,
                                available_versions=Vector{Integer})
     terminal = TTYTerminal("xterm", state.ins, state.outs, state.outs)
-    version_selected = request(terminal, "Select the preferred $(compiler) version",
-                               RadioMenu(string.(available_versions)))
+    message = "Select the preferred $(compiler) version (default: $(first(available_versions)))"
+    version_selected = request(terminal, message, RadioMenu(string.(available_versions)))
     if compiler == "GCC"
         state.preferred_gcc_version = available_versions[version_selected]
     elseif compiler == "LLVM"
@@ -404,8 +404,10 @@ function step2(state::WizardState)
     get_name_and_version(state)
     if yn_prompt(state, "Do you want to customize the set of compilers?", :n) == :y
         get_compilers(state)
+        # Default GCC version is the oldest one
         get_preferred_version(state, "GCC", getversion.(available_gcc_builds))
-        get_preferred_version(state, "LLVM", getversion.(available_llvm_builds))
+        # Default LLVM version is the latest one
+        get_preferred_version(state, "LLVM", getversion.(reverse(available_llvm_builds)))
     else
         state.compilers = [:c]
         # Default GCC version is the oldest one

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -119,7 +119,9 @@ end
     @test state.source_hashes == [libfoo_tarball_hash]
     @test Set(state.compilers) == Set([:c, :rust, :go])
     @test state.preferred_gcc_version == getversion(available_gcc_builds[1])
-    @test state.preferred_llvm_version == getversion(BinaryBuilder.available_llvm_builds[end])
+    # The default LLVM shard is the latest one, and above we pressed three times
+    # arrow down in the reverse order list.
+    @test state.preferred_llvm_version == getversion(BinaryBuilder.available_llvm_builds[end-3])
 
     # Test two tar.gz download
     state = step2_state()


### PR DESCRIPTION
This is done to match the fact that the default LLVM compiler is the latest one,
rather than the oldest one as it is for GCC.