### PR TITLE
Add cxxstringabi mismatches to tests and $CC -lgfortran tests

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2110,27 +2110,27 @@ os = "linux"
     sha256 = "7e198fa9a95c7a3ece03c79dd3e9ee35a9e1e5737d2222987f4dbb3bf3519bf0"
     url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/PlatformSupport-v2020.1.15/PlatformSupport-x86_64-w64-mingw32.v2020.1.15.x86_64-linux-musl.unpacked.tar.gz"
 
-[["Rootfs.v2020.1.29.x86_64-linux-musl.squashfs"]]
+[["Rootfs.v2020.1.30.x86_64-linux-musl.squashfs"]]
 arch = "x86_64"
-git-tree-sha1 = "227b857e27ddbd239000a48f121b0b8ff3729387"
+git-tree-sha1 = "5e71189306517438a3451807bfa920a48ecb239e"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2020.1.29.x86_64-linux-musl.squashfs".download]]
-    sha256 = "f9463d48fca4ab3db39e9d6a529cf4015f1ca239f4eb2ee475f4fb20d25332aa"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2020.1.29/Rootfs.v2020.1.29.x86_64-linux-musl.squashfs.tar.gz"
+    [["Rootfs.v2020.1.30.x86_64-linux-musl.squashfs".download]]
+    sha256 = "13418e1e53d2d23d971f348606c7a096764afc18e9f9ad0b74c73f6290de4c11"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2020.1.30/Rootfs.v2020.1.30.x86_64-linux-musl.squashfs.tar.gz"
 
-[["Rootfs.v2020.1.29.x86_64-linux-musl.unpacked"]]
+[["Rootfs.v2020.1.30.x86_64-linux-musl.unpacked"]]
 arch = "x86_64"
-git-tree-sha1 = "6aef6a25b707de7f6f9587cc57c1334a52ce5276"
+git-tree-sha1 = "4ec521ae8dc18736c728ea21efdde5ce59d77756"
 lazy = true
 libc = "musl"
 os = "linux"
 
-    [["Rootfs.v2020.1.29.x86_64-linux-musl.unpacked".download]]
-    sha256 = "ad6e146672e8153434df9f5d3b0229d714ae26e397cdc1db6f1b9cabe8cc914d"
-    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2020.1.29/Rootfs.v2020.1.29.x86_64-linux-musl.unpacked.tar.gz"
+    [["Rootfs.v2020.1.30.x86_64-linux-musl.unpacked".download]]
+    sha256 = "a52e78e937050f21787b37b4452c57d109e8ee577e0e7ef7b20100515b0ce8eb"
+    url = "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Rootfs-v2020.1.30/Rootfs.v2020.1.30.x86_64-linux-musl.unpacked.tar.gz"
 
 [["RustBase.v1.18.3.x86_64-linux-gnu.squashfs"]]
 arch = "x86_64"

--- a/src/Rootfs.jl
+++ b/src/Rootfs.jl
@@ -415,7 +415,7 @@ consists of four shards, but that may not always be the case.
 """
 function choose_shards(p::Platform;
             compilers::Vector{Symbol} = [:c],
-            rootfs_build::VersionNumber=v"2020.01.29",
+            rootfs_build::VersionNumber=v"2020.01.30",
             ps_build::VersionNumber=v"2020.01.15",
             GCC_builds::Vector{GCCBuild}=available_gcc_builds,
             LLVM_builds::Vector{LLVMBuild}=available_llvm_builds,

--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -198,7 +198,7 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
 
         # On macOS, if we're on an old GCC, the default -syslibroot that gets
         # passed to the linker isn't calculated correctly, so we have to manually set it.
-        if select_gcc_version(p).major == 4
+        if select_gcc_version(p).major in (4, 5)
             FLAGS *= " -Wl,-syslibroot,/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root"
         end
         return FLAGS
@@ -212,12 +212,12 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
 
         # On macOS, if we're on an old GCC, the default -syslibroot that gets
         # passed to the linker isn't calculated correctly, so we have to manually set it.
-        if select_gcc_version(p).major == 4
+        if select_gcc_version(p).major in (4, 5)
             FLAGS *= " -Wl,-syslibroot,/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root"
         end
         return FLAGS
     end
-        
+
     # For MacOS and FreeBSD, we don't set `-rtlib`, and FreeBSD is special-cased within the LLVM source tree
     # to not allow for -gcc-toolchain, which means that we have to manually add the location of libgcc_s.  LE SIGH.
     # We do that within `clang_linker_flags()`, so that we don't get "unused argument" warnings all over the place.

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -148,8 +148,10 @@ end
         install_license /usr/share/licenses/libuv/LICENSE
     """
     platform = Linux(:x86_64)
-    @test_logs (:warn, r"contains std::string values") match_mode=:any begin
-        do_build(build_path, script, platform, v"6")
+    mktempdir() do build_path
+        @test_logs (:warn, r"contains std::string values") match_mode=:any begin
+            do_build(build_path, script, platform, v"6")
+        end
     end
 end
 

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -72,34 +72,39 @@ end
 end
 
 @testset "Auditor - cxxabi selection" begin
+    libcxxstringabi_test = LibraryProduct("libcxxstringabi_test", :libcxxstringabi_test)
+
+    # Factor the autobuild() out
+    function do_build(build_path, script, platform, gcc_version)
+        autobuild(
+            build_path,
+            "libcxxstringabi_test",
+            v"1.0.0",
+            # Copy in the build_tests sources
+            [build_tests_dir],
+            script,
+            # Build for this platform
+            [platform],
+            # The products we expect to be build
+            [libcxxstringabi_test],
+            # No depenedencies
+            [];
+            preferred_gcc_version=gcc_version
+        )
+    end
+
     for platform in (Linux(:x86_64; compiler_abi=CompilerABI(;cxxstring_abi=:cxx03)),
                      Linux(:x86_64; compiler_abi=CompilerABI(;cxxstring_abi=:cxx11)))
         # Look across multiple gcc versions; there can be tricksy interactions here
         for gcc_version in (v"4", v"6", v"9")
             # Do each build within a separate temporary directory
             mktempdir() do build_path
-                libcxxstringabi_test = LibraryProduct("libcxxstringabi_test", :libcxxstringabi_test)
-                build_output_meta = autobuild(
-                    build_path,
-                    "libcxxstringabi_test",
-                    v"1.0.0",
-                    # Copy in the libfoo sources
-                    [build_tests_dir],
-                    # Easy build script
-                    raw"""
+                script = raw"""
                     cd ${WORKSPACE}/srcdir/cxxstringabi_tests
                     make install
                     install_license /usr/share/licenses/libuv/LICENSE
-                    """,
-                    # Build for this platform
-                    [platform],
-                    # The products we expect to be build
-                    [libcxxstringabi_test],
-                    # No depenedencies
-                    [];
-                    preferred_gcc_version=gcc_version
-                )
-
+                """
+                build_output_meta = do_build(build_path, script, platform, gcc_version)
                 # Extract our platform's build
                 @test haskey(build_output_meta, platform)
                 tarball_path, tarball_hash = build_output_meta[platform][1:2]
@@ -117,8 +122,34 @@ end
                     detected_cxxstring_abi = BinaryBuilder.detect_cxxstring_abi(oh, platform)
                     @test detected_cxxstring_abi == cxxstring_abi(platform)
                 end
+
+                # Explicitly test cxx string abi mismatches
+                if gcc_version > v"4"
+                    script = """
+                        mkdir -p \${libdir}
+                        /opt/\${target}/bin/\${target}-g++ -fPIC \\
+                            -D_GLIBCXX_USE_CXX11_ABI=$(cxxstring_abi(platform) == :cxx03 ? "1" : "0") \\
+                            -o \${libdir}/libcxxstringabi_test.\${dlext} \\
+                            -shared \${WORKSPACE}/srcdir/cxxstringabi_tests/lib.cc
+                        install_license /usr/share/licenses/libuv/LICENSE
+                    """
+                    @test_logs (:warn, r"ignoring our choice of compiler") match_mode=:any begin
+                        do_build(build_path, script, platform, gcc_version)
+                    end
+                end
             end
         end
+    end
+
+    # Explicitly test not setting a cxx string abi at all
+    script = raw"""
+        cd ${WORKSPACE}/srcdir/cxxstringabi_tests
+        make install
+        install_license /usr/share/licenses/libuv/LICENSE
+    """
+    platform = Linux(:x86_64)
+    @test_logs (:warn, r"contains std::string values") match_mode=:any begin
+        do_build(build_path, script, platform, v"6")
     end
 end
 


### PR DESCRIPTION
This should get coverage of the strange case where someone manages to ignore our compiler choice and generate cxx11 code on a cxx03 build.

Don't merge until we are certain that the coverage includes all branches of the cxxstring abi checking functions