### PR TITLE
Add `.julia/artifacts` to Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 cache:
   directories:
     - deps
+    - /home/travis/.julia/artifacts
 
 jobs:
   allow_failures:


### PR DESCRIPTION
`deps` is probably not caching much anymore, most of the files are now saved to `.julia/artifacts`