### PR TITLE
Run Travis only on specific branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ notifications:
   email: false
 git:
   depth: 99999999
-sudo: required
 
 env:
   global:
@@ -23,8 +22,7 @@ cache:
 
 jobs:
   allow_failures:
-    julia:
-      - nightly
+    julia: nightly
   include:
     # Add a job that uses the privileged builder with squashfs shards
     - julia: 1.3
@@ -50,6 +48,13 @@ jobs:
         - julia --project=docs -e 'using Pkg; Pkg.instantiate()'
         - julia --project=docs --color=yes docs/make.jl
       after_success: skip
+
+branches:
+  only:
+  - master
+  - gh-pages # For building documentation
+  - /^testing-.*$/ # testing branches
+  - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 
 script:
    - julia --project -e 'using Pkg; Pkg.add(PackageSpec(name="BinaryProvider", rev="master"))'


### PR DESCRIPTION
This also fixes warnings in the configuration of the build