### PR TITLE
Remove duplicate license file

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1202,19 +1202,6 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
               """)
     end
 
-    # Generate LICENSE.md
-    open(joinpath(code_dir, "LICENSE.md"), "w") do io
-        print(io, """
-        Copyright $(year(now()))
-
-        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-        The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-        """)
-    end
-
     # Add a Project.toml
     project = build_project_dict(src_name, build_version, dependencies)
     open(joinpath(code_dir, "Project.toml"), "w") do io


### PR DESCRIPTION
The license file now is created by `init_jll_package`, no need to create another
one in `build_jll_package`.