### PR TITLE
Fix error in local registration/deployment

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -227,7 +227,8 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         end
 
         # For deploy discard build-only dependencies
-        filter!(dep -> !isa(dep, BuildDependency), dependencies)
+        # and make sure we get a `Vector{Dependency}`
+        dependencies = Dependency[dep for dep in dependencies if !isa(dep, BuildDependency)]
 
         # The location the binaries will be available from
         bin_path = "https://github.com/$(deploy_jll_repo)/releases/download/$(tag)"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -226,9 +226,8 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
             @info("Committing and pushing $(src_name)_jll.jl wrapper code version $(build_version)...")
         end
 
-        # For deploy discard build-only dependencies and transform in PackageSpec
+        # For deploy discard build-only dependencies
         filter!(dep -> !isa(dep, BuildDependency), dependencies)
-        dependencies = getpkg.(dependencies)
 
         # The location the binaries will be available from
         bin_path = "https://github.com/$(deploy_jll_repo)/releases/download/$(tag)"


### PR DESCRIPTION
`build_project_dict()` expects Dependencies, so the prior transformation of dependencies into PkgSpecs breaks local deploy/registration.

Without this following error occurs:
```
 Info: SHA256 of hidapi.v0.9.0.i686-w64-mingw32.tar.gz: ea10d874bbc9aa07f56f8f88a0559f2b7c9f13d5eb16a10362500685aa0feff8
[ Info: Committing and pushing hidapi_jll.jl wrapper code version 0.9.0+0...
[ Info: Generating jll package for i686-w64-mingw32 in /home/gerhard/.julia/dev/hidapi_jll
ERROR: LoadError: MethodError: no method matching build_project_dict(::String, ::VersionNumber, ::Array{Pkg.Types.PackageSpec,1})
Closest candidates are:
  build_project_dict(::Any, ::Any, ::Array{Dependency,N} where N) at /home/gerhard/.julia/packages/BinaryBuilder/xbKKQ/src/AutoBuild.jl:1263
Stacktrace:
 [1] #build_jll_package#366(::Bool, ::Bool, ::typeof(BinaryBuilder.build_jll_package), ::String, ::VersionNumber, ::String, ::Dict{Any,Any}, ::Array{Pkg.Types.PackageSpec,1}, ::String) at /home/gerhard/.julia/packages/BinaryBuilder/xbKKQ/src/AutoBuild.jl:1219
 [2] (::BinaryBuilder.var"#kw##build_jll_package")(::NamedTuple{(:verbose,),Tuple{Bool}}, ::typeof(BinaryBuilder.build_jll_package), ::String, ::VersionNumber, ::String, ::Dict{Any,Any}, ::Array{Pkg.Types.PackageSpec,1}, ::String) at ./none:0
 [3] #build_tarballs#323(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(build_tarballs), ::Array{String,1}, ::String, ::VersionNumber, ::Array{GitSource,1}, ::String, ::Array{Platform,1}, ::Array{LibraryProduct,1}, ::Array{Dependency,1}) at /home/gerhard/.julia/packages/BinaryBuilder/xbKKQ/src/AutoBuild.jl:235
 [4] build_tarballs(::Array{String,1}, ::String, ::VersionNumber, ::Array{GitSource,1}, ::String, ::Array{Platform,1}, ::Array{LibraryProduct,1}, ::Array{Dependency,1}) at /home/gerhard/.julia/packages/BinaryBuilder/xbKKQ/src/AutoBuild.jl:24
```