### PR TITLE
`remoteurl` seems to disable fetching, for some reason.

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -809,7 +809,7 @@ function init_jll_package(name, code_dir, deploy_repo;
     else
         # Otherwise, hard-reset to latest master:
         repo = LibGit2.GitRepo(code_dir)
-        LibGit2.fetch(repo; remoteurl="https://github.com/$(deploy_repo)")
+        LibGit2.fetch(repo)
         origin_master_oid = LibGit2.GitHash(LibGit2.lookup_branch(repo, "origin/master", true))
         LibGit2.reset!(repo, origin_master_oid, LibGit2.Consts.RESET_HARD)
         if string(LibGit2.head_oid(repo)) != string(origin_master_oid)


### PR DESCRIPTION
Not sure why this doesn't work