### PR TITLE
Do not replace existing artifacts

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -305,7 +305,7 @@ function upload_to_github_releases(repo, tag, path; attempts::Int = 3, verbose::
     for attempt in 1:attempts
         try
             ghr() do ghr_path
-                run(`$ghr_path -replace -u $(dirname(repo)) -r $(basename(repo)) $(tag) $(path)`)
+                run(`$ghr_path -u $(dirname(repo)) -r $(basename(repo)) $(tag) $(path)`)
             end
             return
         catch


### PR DESCRIPTION
This feature is useful in theory, but causes a lot of harm in practice, for example if `get_next_wrapper_version` fails to get the version number right for unknown reasons.

Fix #554.