### PR TITLE
Add two build tips about building with dependencies

### DIFF
--- a/docs/src/build_tips.md
+++ b/docs/src/build_tips.md
@@ -182,3 +182,39 @@ In addition to the standard Unix tools, in the build environment there are some 
   update_configure_scripts
   ```
   to get a newer version
+
+
+## Header files of the dependencies can't be found
+
+Sometimes the build system can't find the header files of the dependencies, even if they're properly installed.  When this happens, you have to inform the C/C++ preprocessor where the files are.
+
+For example, if the project uses Autotools you can set the `CPPFLAGS` environment variable:
+
+```sh
+export CPPFLAGS="-I${prefix}/include"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nprocs}
+make install
+```
+
+See for example [Cairo](https://github.com/JuliaPackaging/Yggdrasil/blob/9a1ae803823e0dba7628bc71ff794d0c79e39c95/C/Cairo/build_tarballs.jl#L16-L17) build script.
+
+If instead the project uses CMake you'll need to use a different environment variable, since CMake ignores `CPPFLAGS`.  If the compiler that can't find the header file is the C one, you need to add the path to the `CFLAGS` variable (e.g., `CFLAGS="-I${prefix}/include"`), in case it's the C++ one you have to set the `CXXFLAGS` variable (e.g., `CXXFLAGS="-I${prefix}/include"`).  
+(original
+ [source](https://github.com/JuliaPackaging/Yggdrasil/wiki/Build-Tricks#header-files-of-the-dependencies-cant-be-found))
+
+
+## Libraries of the dependencies can't be found
+
+Like in the section above, it may happen that the build system fails to find the libraries of the dependencies, even when they're installed to the right place.  In these case, you have to inform the linker where the libraries are by setting the `LDFLAGS` environment variable:
+
+```sh
+export LDFLAGS="-L${libdir}"
+./configure --prefix=${prefix} --build=${MACHTYPE} --host=${target}
+make -j${nprocs}
+make install
+```
+
+See for example [libwebp](https://github.com/JuliaPackaging/Yggdrasil/blob/9a1ae803823e0dba7628bc71ff794d0c79e39c95/L/libwebp/build_tarballs.jl#L19-L21) build script (in this case this was needed only when building for FreeBSD).  
+(original
+ [source](https://github.com/JuliaPackaging/Yggdrasil/wiki/Build-Tricks#libraries-of-the-dependencies-cant-be-found))


### PR DESCRIPTION
I find it highly confusing that there are two sources for build tips for BinaryBuilder.jl: one is the Yggdrasil GitHub wiki and one can be found in the official docs. Since I am not familiar with the original rationale behind this choice, I would at least propose to include these two build tips in the official docs, as they seem to be very helpful for novice users and at least I was only able to find them by asking for help.

If it were possible to get consensus from everyone involved, I'd actually propose to close down the wiki at Yggdrasil and move all documentation to here. IMHO, that would be the best solution for new users.