### PR TITLE
Update travis configuration to match comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,17 +28,19 @@ jobs:
     - julia: 1.3
       env:
         - BINARYBUILDER_RUNNER=privileged
-        - BINARYBUILDER_USER_SQUASHFS=true
+        - BINARYBUILDER_USE_SQUASHFS=true
 
     # Add a job that uses the unprivileged builder with unpacked shards
     - julia: 1.3
       env:
         - BINARYBUILDER_RUNNER=unprivileged
+        - BINARYBUILDER_USE_SQUASHFS=false
 
     # Add a job that uses the docker builder with unpacked shards
     - julia: 1.3.0
       env:
         - BINARYBUILDER_RUNNER=docker
+        - BINARYBUILDER_USE_SQUASHFS=false
 
     # Build the docs!
     - stage: Documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - BINARYBUILDER_USE_SQUASHFS=true
 
     # Add a job that uses the unprivileged builder with unpacked shards
-    - julia: 1.3.1
+    - julia: 1.3.0
       env:
         - BINARYBUILDER_RUNNER=unprivileged
         - BINARYBUILDER_USE_SQUASHFS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - BINARYBUILDER_USE_SQUASHFS=true
 
     # Add a job that uses the unprivileged builder with unpacked shards
-    - julia: 1.3
+    - julia: 1.3.1
       env:
         - BINARYBUILDER_RUNNER=unprivileged
         - BINARYBUILDER_USE_SQUASHFS=false


### PR DESCRIPTION
On travis, we default to squashfs shards, so in order to test unpacked shards,
we need to set the env var to false. Also it was misspelled for the one instance
where it was set.