### PR TITLE
Fix filtering of armv7l platforms in JLL wrappers for Julia v1.3

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1155,7 +1155,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
         platforms = [Pkg.Artifacts.unpack_platform(e, $(repr(src_name)), artifacts_toml) for e in artifacts[$(repr(src_name))]]
 
         # Filter platforms based on what wrappers we've generated on-disk
-        platforms = filter(p -> isfile(joinpath(@__DIR__, "wrappers", triplet(p) * ".jl")), platforms)
+        filter!(p -> isfile(joinpath(@__DIR__, "wrappers", replace(triplet(p), "arm-" => "armv7l-") * ".jl")), platforms)
 
         # From the available options, choose the best platform
         best_platform = select_platform(Dict(p => triplet(p) for p in platforms))


### PR DESCRIPTION
This is what Julia v1.3 is doing now on armv7l to select the best platform in the JLL wrapper, for example for OpenSpecFun:
```julia
julia> using Pkg, Pkg.BinaryPlatforms, Pkg.Artifacts, Libdl

julia> import Base: UUID

julia> artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
"/home/mose/.julia/packages/OpenSpecFun_jll/G7uZt/src/../Artifacts.toml"

julia> artifacts = Pkg.Artifacts.load_artifacts_toml(artifacts_toml; pkg_uuid=UUID("efe28fd5-8261-553b-a9e1-b2916fc3738e"))
Dict{String,Any} with 1 entry:
  "OpenSpecFun" => Dict{String,Any}[Dict("libgfortran_version"=>"5.0.0","arch"=>"x86_64","git-tree-sha1"=>"a81bd38b8d5212f36c6b7fbe09562daef575…

julia> platforms = [Pkg.Artifacts.unpack_platform(e, "OpenSpecFun", artifacts_toml) for e in artifacts["OpenSpecFun"]]
39-element Array{Platform,1}:
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                             
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                             
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                               
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                 
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                               
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                               
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0")) 
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                     
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))             
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0")) 
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                 
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))             
 Windows(:i686, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                               
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0")) 
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))
 ⋮                                                                                                    
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                             
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                             
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                 
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                   
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                   
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                             
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                   
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                    
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                    
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                             
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                     
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                     
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))             

julia> platforms = filter(p -> isfile(joinpath(@__DIR__, "wrappers", triplet(p) * ".jl")), platforms)
33-element Array{Platform,1}:
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))    
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))     
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))        
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))    
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))
 Windows(:i686, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))     
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))     
 Windows(:i686, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))       
 Windows(:i686, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))    
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))      
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))      
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))     
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))      
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))     
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))       
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))       
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))        
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))        
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))     
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))

julia> best_platform = select_platform(Dict(p => triplet(p) for p in platforms), Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0")))

julia> isnothing(ans)
true
```
This is what it would do with this PR:
```julia
julia> using Pkg, Pkg.BinaryPlatforms, Pkg.Artifacts, Libdl

julia> import Base: UUID

julia> artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
"/home/mose/.julia/packages/OpenSpecFun_jll/G7uZt/src/../Artifacts.toml"

julia> artifacts = Pkg.Artifacts.load_artifacts_toml(artifacts_toml; pkg_uuid=UUID("efe28fd5-8261-553b-a9e1-b2916fc3738e"))
Dict{String,Any} with 1 entry:
  "OpenSpecFun" => Dict{String,Any}[Dict("libgfortran_version"=>"5.0.0","arch"=>"x86_64","git-tree-sha1"=>"a81bd38b8d5212f36c6b7fbe09562daef575…

julia> platforms = [Pkg.Artifacts.unpack_platform(e, "OpenSpecFun", artifacts_toml) for e in artifacts["OpenSpecFun"]]
39-element Array{Platform,1}:
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                             
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                             
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                               
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                 
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                               
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                               
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0")) 
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                     
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))             
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0")) 
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                 
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))             
 Windows(:i686, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                               
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0")) 
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))
 ⋮                                                                                                    
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                             
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                             
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                 
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                   
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                   
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                             
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                   
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                    
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                    
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                             
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                     
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                     
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))             

julia> filter!(p -> isfile(joinpath(@__DIR__, "wrappers", replace(triplet(p), "arm-" => "armv7l-") * ".jl")), platforms)
39-element Array{Platform,1}:
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                             
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                             
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                               
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                 
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                               
 MacOS(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                               
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0")) 
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                     
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))             
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0")) 
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                 
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))             
 Windows(:i686, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                               
 Linux(:armv7l, libc=:musl, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0")) 
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                  
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))
 ⋮                                                                                                    
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                             
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                             
 Linux(:aarch64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                 
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                   
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                   
 Windows(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                             
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))
 Linux(:x86_64, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                   
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                  
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                    
 Linux(:i686, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                    
 FreeBSD(:x86_64, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                             
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"3.0.0"))                     
 Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))
 Linux(:i686, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))                     
 Linux(:aarch64, libc=:musl, compiler_abi=CompilerABI(libgfortran_version=v"5.0.0"))                  
 Linux(:powerpc64le, libc=:glibc, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0"))             

julia> best_platform = select_platform(Dict(p => triplet(p) for p in platforms), Linux(:armv7l, libc=:glibc, call_abi=:eabihf, compiler_abi=CompilerABI(libgfortran_version=v"4.0.0")))
"arm-linux-gnueabihf-libgfortran4"
```