### PR TITLE
Add `-Wno-unused-command-line-argument` to `clang` wrapper

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -244,7 +244,8 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
     # Next, on MacOS, we need to override the typical C++ include search paths, because it always includes
     # the toolchain C++ headers first.  Valentin tracked this down to:
     # https://github.com/llvm/llvm-project/blob/0378f3a90341d990236c44f297b923a32b35fab1/clang/lib/Driver/ToolChains/Darwin.cpp#L1944-L1978
-    clang_compile_flags(p::MacOS) = String["-nostdinc++", "-isystem", "/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include/c++/v1"]
+    # We also add `-Wno-unused-command-line-argument` so that if someone does something like `clang -Werror -o foo a.o b.o`, it doesn't complain.
+    clang_compile_flags(p::MacOS) = String["-Wno-unused-command-line-argument", "-nostdinc++", "-isystem", "/opt/$(aatriplet(p))/$(aatriplet(p))/sys-root/usr/include/c++/v1"]
 
     # For everything else, there's MasterCard (TM) (.... also, we need to provide `-rtlib=libgcc` because clang-builtins are broken,
     # and we also need to provide `-stdlib=libstdc++` to match Julia on these platforms.)


### PR DESCRIPTION
This avoids things breaking because of the flags we insert.  Example: https://github.com/JuliaPackaging/Yggdrasil/pull/559