### PR TITLE
Add basic support for macOS frameworks

### DIFF
--- a/src/Declarative.jl
+++ b/src/Declarative.jl
@@ -41,6 +41,8 @@ function cleanup_merged_object!(meta::Dict)
             return ExecutableProduct(p)
         elseif p["type"] == "lib"
             return LibraryProduct(p)
+        elseif p["type"] == "framework"
+            return FrameworkProduct(p)
         elseif p["type"] == "file"
             return FileProduct(p)
         else

--- a/test/build_tests/libfoo/CMakeLists.txt
+++ b/test/build_tests/libfoo/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 add_library(foo SHARED libfoo.c)
+add_library(fooFramework SHARED libfoo.c)
 
 add_executable(fooifier fooifier.cpp)
 target_link_libraries(fooifier foo)
@@ -9,10 +10,12 @@ target_link_libraries(fooifier foo)
 # Enable relative RPATH
 if (APPLE)
     set_target_properties(fooifier PROPERTIES INSTALL_RPATH "@executable_path/../lib")
+    set_target_properties(fooFramework PROPERTIES FRAMEWORK TRUE FRAMEWORK_VERSION C)
 elseif (UNIX)
     set_target_properties(fooifier PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
 install(TARGETS foo DESTINATION lib)
+install(TARGETS fooFramework DESTINATION lib)
 install(TARGETS fooifier RUNTIME DESTINATION bin)
 

--- a/test/building.jl
+++ b/test/building.jl
@@ -302,3 +302,33 @@ end
     end
     @test haskey(build_output_meta, platform)
 end
+
+@testset "Building framework" begin
+    mac_shards = filter(p -> p isa MacOS, shards_to_test)
+    if isempty(mac_shards)
+        mac_shards = [MacOS()] # Make sure to always also test this using MacOS
+    end
+    # The framework is only built as a framework on Mac and using CMake, and a regular lib elsewhere
+    script = libfoo_cmake_script
+    products = [FrameworkProduct("fooFramework", :libfooFramework)]
+    # Do build within a separate temporary directory
+    mktempdir() do build_path
+        products = [FrameworkProduct("fooFramework", :libfooFramework)]
+
+        build_output_meta = autobuild(
+            build_path,
+            "libfoo",
+            v"1.0.0",
+            # No sources
+            [DirectorySource(build_tests_dir)],
+            # Build the test suite, install the binaries into our prefix's `bin`
+            libfoo_cmake_script,
+            # Build for ALL the platforms
+            mac_shards,
+            products,
+            # No dependencies
+            Dependency[];
+            verbose=true,
+        )
+    end
+end

--- a/test/declarative.jl
+++ b/test/declarative.jl
@@ -13,7 +13,7 @@ import BinaryBuilder: sourcify, dependencify
             [FileSource("https://julialang.org", "123123"), DirectorySource("./bundled")],
             "exit 1",
             [Linux(:x86_64)],
-            Product[LibraryProduct("libfoo", :libfoo)],
+            Product[LibraryProduct("libfoo", :libfoo), FrameworkProduct("fooFramework", :libfooFramework)],
             [Dependency("Zlib_jll")];
             meta_json_stream=meta_json_buff,
         )
@@ -79,8 +79,8 @@ import BinaryBuilder: sourcify, dependencify
         @test d.pkg.version.ranges[1].lower.t == ref_d.pkg.version.ranges[1].lower.t
         @test d.pkg.version.ranges[1].lower.n == ref_d.pkg.version.ranges[1].lower.n
         @test_throws ErrorException dependencify(Dict("type" => "bar"))
-        @test length(meta["products"]) == 2
-        @test all(in.((LibraryProduct("libfoo", :libfoo), ExecutableProduct("julia", :julia)), Ref(meta["products"])))
+        @test length(meta["products"]) == 3
+        @test all(in.((LibraryProduct("libfoo", :libfoo), ExecutableProduct("julia", :julia), FrameworkProduct("fooFramework", :libfooFramework)), Ref(meta["products"])))
         @test length(meta["script"]) == 2
         @test all(in.(("exit 0", "exit 1"), Ref(meta["script"])))
     end


### PR DESCRIPTION
As discussed in https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/393#issuecomment-581182957, this adds basic support for macOS frameworks, limited to the following:
* Find a framework that matches the provided name with the `.framework` suffix
* Resolve the library that is inside the framework with its version

On non-macOS platforms, the `FrameworkProduct` behaves just like a `LibraryProduct`, so this is mainly intended for libraries like Qt that offer a Framework on macOS and normal libraries on other platforms.
