### PR TITLE
Dlopen flags 2

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1091,7 +1091,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                     println(io, """
                         # Manually `dlopen()` this right now so that future invocations
                         # of `ccall` with its `SONAME` will find this path immediately.
-                        global $(vp)_handle = dlopen($(vp)_path)
+                        global $(vp)_handle = $(dlopen_str("$(vp)_path", p.dlopen_flags))
                         push!(LIBPATH_list, dirname($(vp)_path))
                     """)
                 elseif p isa ExecutableProduct

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1091,7 +1091,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                     println(io, """
                         # Manually `dlopen()` this right now so that future invocations
                         # of `ccall` with its `SONAME` will find this path immediately.
-                        global $(vp)_handle = $(dlopen_str("$(vp)_path", p.dlopen_flags))
+                        global $(vp)_handle = dlopen($(vp)_path$(dlopen_flags_str(p.dlopen_flags)))
                         push!(LIBPATH_list, dirname($(vp)_path))
                     """)
                 elseif p isa ExecutableProduct

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -445,3 +445,11 @@ end
     @test next_version.minor == version.minor
     @test next_version.patch == version.patch
 end
+
+@testset "Dlopen flags" begin
+    prod = LibraryProduct("libfoo2", :libfoo2; dlopen_flags=[:RTLD_GLOBAL, :RTLD_NOLOAD])
+    @test prod.dlopen_flags == [:RTLD_GLOBAL, :RTLD_NOLOAD]
+    flag_str = BinaryBuilder.dlopen_flags_str(prod.dlopen_flags)
+    @test flag_str == ", RTLD_GLOBAL | RTLD_NOLOAD"
+    @test eval(Meta.parse(flag_str[3:end])) == (RTLD_NOLOAD | RTLD_GLOBAL)
+end

--- a/test/declarative.jl
+++ b/test/declarative.jl
@@ -26,7 +26,7 @@ import BinaryBuilder: sourcify, dependencify
             [GitSource("https://github.com/JuliaLang/julia.git", "5d4eaca0c9fa3d555c79dbacdccb9169fdf64b65")],
             "exit 0",
             [Linux(:x86_64), Windows(:x86_64)],
-            Product[ExecutableProduct("julia", :julia)],
+            Product[ExecutableProduct("julia", :julia), LibraryProduct("libfoo2", :libfoo2; dlopen_flags=[:RTLD_GLOBAL])],
             Dependency[];
             meta_json_stream=meta_json_buff,
         )
@@ -79,8 +79,8 @@ import BinaryBuilder: sourcify, dependencify
         @test d.pkg.version.ranges[1].lower.t == ref_d.pkg.version.ranges[1].lower.t
         @test d.pkg.version.ranges[1].lower.n == ref_d.pkg.version.ranges[1].lower.n
         @test_throws ErrorException dependencify(Dict("type" => "bar"))
-        @test length(meta["products"]) == 3
-        @test all(in.((LibraryProduct("libfoo", :libfoo), ExecutableProduct("julia", :julia), FrameworkProduct("fooFramework", :libfooFramework)), Ref(meta["products"])))
+        @test length(meta["products"]) == 4
+        @test all(in.((LibraryProduct("libfoo", :libfoo), ExecutableProduct("julia", :julia), LibraryProduct("libfoo2", :libfoo2; dlopen_flags=[:RTLD_GLOBAL]), FrameworkProduct("fooFramework", :libfooFramework)), Ref(meta["products"])))
         @test length(meta["script"]) == 2
         @test all(in.(("exit 0", "exit 1"), Ref(meta["script"])))
     end


### PR DESCRIPTION
This is an update of PR #453 with the following changes:

* Retain the `dont_dlopen` field and parameter name
* Fix a bug where instead of the library, it tried to dlopen a file with the variable name as name
* Some basic testing