### PR TITLE
Dereference symlinks when copying `DirectorySource`s

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -308,8 +308,9 @@ function setup(source::SetupSource{DirectorySource}, targetdir, verbose)
         @info "Copying content of $(basename(srcpath)) in $(basename(targetdir))..."
     end
     for file_dir in readdir(srcpath)
-        # Copy the content of the source directory to the destination
-        cp(joinpath(srcpath, file_dir), joinpath(targetdir, basename(file_dir)))
+        # Copy the content of the source directory to the destination. Note that we DO follow symlinks here!
+        # This is to support symlink patchsets across multiple versions of GCC, etc...
+        cp(joinpath(srcpath, file_dir), joinpath(targetdir, basename(file_dir)); follow_symlinks=true)
     end
 end
 


### PR DESCRIPTION
Usually, we want to preserve symlinks; but in the special case of a `DirectorySource()`, it is very useful to be able to have symlinks pointing out side of the current directory and at some shared patch pool (e.g. in `GCCBootstrap@X`).  So we make the compromise that symlinks are collapsed when including `DirectorySource`'s.