### PR TITLE
Add warning messages about deadlinks

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -708,6 +708,9 @@ function autobuild(dir::AbstractString,
         # Unsymlink all the deps from the dest_prefix
         cleanup_dependencies(prefix, artifact_paths)
 
+        # Search for dead links; raise warnings about them.
+        warn_deadlinks(prefix.path)
+
         # Cull empty directories, for neatness' sake, unless auditing is disabled
         if !skip_audit
             for (root, dirs, files) = walkdir(dest_prefix.path; topdown=false)

--- a/src/auditor/symlink_translator.jl
+++ b/src/auditor/symlink_translator.jl
@@ -18,3 +18,20 @@ function translate_symlinks(root::AbstractString; verbose::Bool=false)
         end
     end
 end
+
+"""
+    warn_deadlinks(root::AbstractString)
+
+Walks through the given `root` directory, finding broken symlinks and warning
+the user about them.  This is used to catch instances such as a build recipe
+copying a symlink that points to a dependency; by doing so, it implicitly
+breaks relocatability.
+"""
+function warn_deadlinks(root::AbstractString)
+    for f in collect_files(root, islink; exclude_externalities=false)
+        link_target = readlink(f)
+        if !isfile(link_target)
+            @warn("Broken symlink: $(relpath(f, root))")
+        end
+    end
+end


### PR DESCRIPTION
This should fix issues such as the recently-diagnosed `HELICS_jll`
issues installing things on windows, where `7z.exe` decided it didn't
want to extract tarballs with deadlinks.