### PR TITLE
Fix `dlopen_flags_str`

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1095,7 +1095,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                     println(io, """
                         # Manually `dlopen()` this right now so that future invocations
                         # of `ccall` with its `SONAME` will find this path immediately.
-                        global $(vp)_handle = dlopen($(vp)_path$(dlopen_flags_str(p.dlopen_flags)))
+                        global $(vp)_handle = dlopen($(vp)_path$(dlopen_flags_str(p)))
                         push!(LIBPATH_list, dirname($(vp)_path))
                     """)
                 elseif p isa ExecutableProduct

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -119,9 +119,9 @@ struct LibraryProduct <: Product
     )
 end
 
-function dlopen_flags_str(dlopen_flags::Vector{Symbol}=Symbol[])
-    if length(dlopen_flags) > 0
-        return ", $(join(dlopen_flags, " | "))"
+function dlopen_flags_str(p::LibraryProduct)
+    if length(p.dlopen_flags) > 0
+        return ", $(join(p.dlopen_flags, " | "))"
     else
         return ""
     end
@@ -291,6 +291,8 @@ function locate(fp::FrameworkProduct, prefix::Prefix; platform::Platform = platf
     end
     return nothing
 end
+
+dlopen_flags_str(p::FrameworkProduct) = dlopen_flags_str(p.libraryproduct)
 
 """
 An `ExecutableProduct` is a [`Product`](@ref) that represents an executable file.

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -447,9 +447,13 @@ end
 end
 
 @testset "Dlopen flags" begin
-    prod = LibraryProduct("libfoo2", :libfoo2; dlopen_flags=[:RTLD_GLOBAL, :RTLD_NOLOAD])
-    @test prod.dlopen_flags == [:RTLD_GLOBAL, :RTLD_NOLOAD]
-    flag_str = BinaryBuilder.dlopen_flags_str(prod.dlopen_flags)
-    @test flag_str == ", RTLD_GLOBAL | RTLD_NOLOAD"
-    @test eval(Meta.parse(flag_str[3:end])) == (RTLD_NOLOAD | RTLD_GLOBAL)
+    lp = LibraryProduct("libfoo2", :libfoo2; dlopen_flags=[:RTLD_GLOBAL, :RTLD_NOLOAD])
+    @test lp.dlopen_flags == [:RTLD_GLOBAL, :RTLD_NOLOAD]
+    fp = FrameworkProduct("libfoo2", :libfoo2; dlopen_flags=[:RTLD_GLOBAL, :RTLD_NOLOAD])
+    @test fp.libraryproduct.dlopen_flags == [:RTLD_GLOBAL, :RTLD_NOLOAD]
+    for p in (lp, fp)
+        flag_str = BinaryBuilder.dlopen_flags_str(p)
+        @test flag_str == ", RTLD_GLOBAL | RTLD_NOLOAD"
+        @test eval(Meta.parse(flag_str[3:end])) == (RTLD_NOLOAD | RTLD_GLOBAL)
+    end
 end


### PR DESCRIPTION
The product can be also a `FrameworkProduct`, which doesn't have a
`dlopen_flags` field.

