### PR TITLE
Fix warning about dead symlinks

### DIFF
--- a/src/auditor/symlink_translator.jl
+++ b/src/auditor/symlink_translator.jl
@@ -30,6 +30,14 @@ breaks relocatability.
 function warn_deadlinks(root::AbstractString)
     for f in collect_files(root, islink; exclude_externalities=false)
         link_target = readlink(f)
+        if !startswith(link_target, "/")
+            # If the link is relative, prepend the dirname of `f` to
+            # `link_target`, otherwise `isfile(link_target)` will always be
+            # false, as the test isn't performed in dirname(f).  Why Not using
+            # `isabspath`?  Because that command is platform-dependent, but we
+            # always build in a Unix-like environment.
+            link_target = joinpath(dirname(f), link_target)
+        end
         if !isfile(link_target)
             @warn("Broken symlink: $(relpath(f, root))")
         end

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -282,7 +282,9 @@ end
         mkpath(bindir)
         # Test both broken and working (but external) symlinks
         symlink("../../artifacts/1a2b3/lib/libzmq.dll.a", joinpath(bindir, "libzmq.dll.a"))
+        # The following symlinks shouldn't raise a warning
         symlink("/bin/bash", joinpath(bindir, "bash.exe"))
+        symlink("libfoo.so.1.2.3", joinpath(bindir, "libfoo.so"))
 
         # Test that `audit()` warns about broken symlinks
         @test_logs (:warn, r"Broken symlink: bin/libzmq.dll.a") match_mode=:any begin


### PR DESCRIPTION
The current implementation shows a warning also if the link target is a relative
path to an existing file, because the check `isfile(link_target)` isn't
performed in the same directory as where the symlink is.

Addresses https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/708#issuecomment-597956747.