### PR TITLE
Record compat info when registering packages

### DIFF
--- a/test/basic.jl
+++ b/test/basic.jl
@@ -449,6 +449,21 @@ end
     @test next_version.major == version.major
     @test next_version.minor == version.minor
     @test next_version.patch == version.patch
+
+    # Ensure passing compat bounds works
+    dependencies = [
+        Dependency(PackageSpec(name="libLLVM_jll", version=v"9")),
+    ]
+    dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
+    @test dict["compat"]["julia"] == "1.0"
+    @test dict["compat"]["libLLVM_jll"] == "9.0.0"
+    
+    dependencies = [
+        Dependency(PackageSpec(name="libLLVM_jll", version="8.3-10")),
+    ]
+    dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
+    @test dict["compat"]["julia"] == "1.0"
+    @test dict["compat"]["libLLVM_jll"] == "8.3-10"
 end
 
 @testset "Dlopen flags" begin


### PR DESCRIPTION
If you specify a certain version of a package to build against, we
should ensure the same version is installed on the user's computer.