### PR TITLE
Search for dead links only in destdir

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -719,8 +719,8 @@ function autobuild(dir::AbstractString,
         # Unsymlink all the deps from the dest_prefix
         cleanup_dependencies(prefix, artifact_paths)
 
-        # Search for dead links; raise warnings about them.
-        warn_deadlinks(prefix.path)
+        # Search for dead links in dest_prefix; raise warnings about them.
+        warn_deadlinks(dest_prefix.path)
 
         # Cull empty directories, for neatness' sake, unless auditing is disabled
         if !skip_audit


### PR DESCRIPTION
[This build](https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=2750&view=results) found lots of dead links in `srcdir/`, but I don't think we really care about them, do we?  We are more interested in catching dead links in `destdir/`, which is the directory that will go into the tarball