### PR TITLE
Add environment variables to {,not} link whole archive

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -32,6 +32,11 @@ exeext(p::Windows) = ".exe"
 exeext(p::Union{Linux,FreeBSD,MacOS}) = ""
 exeext(p::Platform) = error("Unknown exeext for platform $(p)")
 
+whole_archive(p::Platform) = "--whole-archive"
+whole_archive(p::MacOS) = "-all_load"
+nowhole_archive(p::Platform) = "--no-whole-archive"
+nowhole_archive(p::MacOS) = "-noall_load"
+
 # Convert platform to a triplet, but strip out the ABI parts.
 # Also translate `armv7l` -> `arm` for now, since that's what most
 # compiler toolchains call it.  :(
@@ -565,6 +570,8 @@ function platform_envs(platform::Platform, src_name::AbstractString; host_platfo
         "proc_family" => string(proc_family(platform)),
         "dlext" => dlext(platform),
         "exeext" => exeext(platform),
+        "whole_archive" => whole_archive(platform),
+        "nowhole_archive" => nowhole_archive(platform),
         "PATH" => "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
         "MACHTYPE" => "x86_64-linux-musl",
 


### PR DESCRIPTION
Since we often need to convert a static archive into a shared library, I'd like to have as environment variables the flags for the linker needed to do the conversion.  I know we don't export other flags in the same way, so this may not be desirable.

Actually, my ideal solution would be to have a bash command for doing this, but I think that would be a bit too complicated: you have to specify the compiler, the list of archives you want to put together -- ok, usually only one --, extra linker options and extra libraries.  This isn't super easy to do in bash without multiple dispatch :pensive:   This is why I think at least having the whole archive flags available as environment variables would help