### PR TITLE
Add "Wizard service" to modify Wizard state during interactive build

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,11 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgParse]]
+deps = ["Logging", "TextWrap"]
+git-tree-sha1 = "a8fc2e149cd6db276c76faebe197ccd3a92fb9ff"
+uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+version = "1.1.0"
+
 [[AssetRegistry]]
 deps = ["Distributed", "JSON", "Pidfile", "SHA", "Test"]
 git-tree-sha1 = "b25e88db7944f98789130d7b503276bc34bc098e"
@@ -21,15 +27,15 @@ uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
 
 [[DataAPI]]
-git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
+git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.1.0"
+version = "1.3.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "4dead20a1606a60292529023d6eac18a1ef6432e"
+git-tree-sha1 = "6166ecfaf2b8bbf2b68d791bc1d54501f345d314"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.12"
+version = "0.17.15"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -46,9 +52,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FileIO]]
 deps = ["Pkg"]
-git-tree-sha1 = "3d7cb2c4c850439f19c4d6d3fbe1dce6481cddb1"
+git-tree-sha1 = "202335fd24c2776493e198d6c66a6d910400a895"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.2.4"
+version = "1.3.0"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -117,6 +123,7 @@ uuid = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
 version = "0.15.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -178,16 +185,15 @@ uuid = "d8793406-e978-5875-9003-1fc021f44a92"
 version = "0.3.3"
 
 [[OrderedCollections]]
-deps = ["Random", "Serialization", "Test"]
-git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+git-tree-sha1 = "12ce190210d278e12644bcadf5b21cbdcf225cd3"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.1.0"
+version = "1.2.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "f8f5d2d4b4b07342e5811d2b6428e45524e241df"
+git-tree-sha1 = "72c3451932513427caffbd8bab15643ad693804b"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.2"
+version = "1.0.3"
 
 [[Pidfile]]
 deps = ["FileWatching", "Test"]
@@ -196,7 +202,7 @@ uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PkgLicenses]]
@@ -231,15 +237,15 @@ version = "0.2.0"
 
 [[Registrator]]
 deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "RegistryTools", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
-git-tree-sha1 = "386f5786cf747cc5b5408006b770d80764a729f3"
+git-tree-sha1 = "fc03fdec0e29ab36e3e994a08cb8272f53f65354"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
-version = "1.1.1"
+version = "1.2.0"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
-git-tree-sha1 = "940e754d4b7b68ecb9037f6bf41a1d6ca586d000"
+git-tree-sha1 = "ea27832a31084895842c77e4f78f5beea9677abd"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
-version = "1.4.0"
+version = "1.5.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -271,6 +277,11 @@ version = "1.0.4"
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TextWrap]]
+git-tree-sha1 = "9250ef9b01b66667380cf3275b3f7488d0e25faf"
+uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
+version = "1.0.1"
 
 [[TimeToLive]]
 deps = ["Dates"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Elliot Saba <staticfloat@gmail.com>"]
 version = "0.2.4"
 
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -199,6 +199,87 @@ function diff_srcdir(state::WizardState, prefix::Prefix, ur::Runner)
     return false
 end
 
+function bb_add(client, state::WizardState, prefix::Prefix, platform::Platform, jll::AbstractString)
+    if any(dep->getpkg(dep).name == jll, state.dependencies)
+        println(client, "ERROR: Package was already added")
+        return
+    end
+    new_dep = Dependency(jll)
+    try
+        # This will redo some work, but that may be ok
+        concrete_platform = get_concrete_platform(platform;
+                                                  preferred_gcc_version = state.preferred_gcc_version,
+                                                  preferred_llvm_version = state.preferred_llvm_version,
+                                                  compilers = state.compilers)
+        setup_dependencies(prefix, getpkg.([state.dependencies; new_dep]), concrete_platform)
+        push!(state.dependencies, new_dep)
+    catch e
+        showerror(client, e)
+    end
+end
+
+using ArgParse
+
+function bb_parser()
+    s = ArgParseSettings()
+
+    @add_arg_table! s begin
+        "add"
+            help = "Add a jll package as if specified at the start of the wizard"
+            action = :command
+    end
+
+    @add_arg_table! s["add"] begin
+        "jll"
+        help = "The jll to add"
+        required = true
+    end
+
+    s
+end
+
+function setup_bb_service(state::WizardState, prefix, platform)
+    fpath = joinpath(prefix, "metadir", "bb_service")
+    server = listen(fpath)
+    @async begin
+        while isopen(server)
+            client = accept(server)
+            function client_error(err)
+                println(client, "ERROR: $err")
+                close(client)
+            end
+            @async while isopen(client)
+                try
+                    cmd = readline(client)
+                    ARGS = split(cmd, " ")
+                    s = bb_parser()
+                    try
+                        popfirst!(ARGS)
+                        parsed = parse_args(ARGS, s)
+                        if parsed == nothing
+                        elseif parsed["%COMMAND%"] == "add"
+                            bb_add(client, state, prefix, platform, parsed["add"]["jll"])
+                        end
+                        close(client)
+                    catch e
+                        if isa(e, ArgParseError)
+                            println(client, "ERROR: ", e.text, "\n")
+                            ArgParse.show_help(client, s)
+                            close(client)
+                        else
+                            rethrow(e)
+                        end
+                    end
+                catch e
+                    showerror(stderr, e)
+                    close(client)
+                end
+            end
+        end
+    end
+    (fpath, server)
+end
+
 """
     interactive_build(state::WizardState, prefix::Prefix,
                       ur::Runner, build_path::AbstractString)
@@ -207,7 +288,8 @@ end
     reproducible steps for building this source. Shared between steps 3 and 5
 """
 function interactive_build(state::WizardState, prefix::Prefix,
-                           ur::Runner, build_path::AbstractString;
+                           ur::Runner, build_path::AbstractString,
+                           platform::Platform;
                            hist_modify = string, srcdir_overlay = true)
     histfile = joinpath(prefix, "metadir", ".bash_history")
     cmd = `/bin/bash -l`
@@ -226,6 +308,8 @@ function interactive_build(state::WizardState, prefix::Prefix,
             cmd = `/bin/bash -c $cmd`
         end
 
+        (fpath, server) = setup_bb_service(state, prefix, platform)
+
         script_successful = run_interactive(ur, ignorestatus(cmd), stdin=state.ins, stdout=state.outs, stderr=state.outs)
 
         had_patches = srcdir_overlay && diff_srcdir(state, prefix, ur)
@@ -236,6 +320,10 @@ function interactive_build(state::WizardState, prefix::Prefix,
         workdir = joinpath(prefix, "metadir", "work", "work")
         if isdir(workdir)
             rm(workdir)
+        end
+        if @isdefined server
+            close(server)
+            rm(fpath)
         end
     end
 
@@ -301,7 +389,7 @@ function step3_interactive(state::WizardState, prefix::Prefix,
                            platform::Platform,
                            ur::Runner, build_path::AbstractString, artifact_paths::Vector{String})
 
-    if interactive_build(state, prefix, ur, build_path)
+    if interactive_build(state, prefix, ur, build_path, platform)
         # Unsymlink all the deps from the dest_prefix before moving to the next step
         cleanup_dependencies(prefix, artifact_paths)
         state.step = :step3_retry
@@ -520,7 +608,7 @@ function step5_internal(state::WizardState, platform::Platform)
                     )
 
                     if choice == 1
-                        if interactive_build(state, prefix, ur, build_path;
+                        if interactive_build(state, prefix, ur, build_path, platform;
                                           hist_modify = function(olds, s)
                             """
                             $olds
@@ -563,7 +651,7 @@ function step5_internal(state::WizardState, platform::Platform)
                             preferred_llvm_version=state.preferred_llvm_version,
                         )
 
-                        if interactive_build(state, prefix, ur, build_path;
+                        if interactive_build(state, prefix, ur, build_path, platform;
                                           hist_modify = function(olds, s)
                             """
                             if [ \$target != "$(triplet(platform))" ]; then

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -296,6 +296,8 @@ function interactive_build(state::WizardState, prefix::Prefix,
 
     had_patches = false
     script_successful = false
+    server = nothing
+    fpath = nothing
     try
         if srcdir_overlay
             mkpath(joinpath(prefix, "metadir", "upper"))
@@ -321,9 +323,9 @@ function interactive_build(state::WizardState, prefix::Prefix,
         if isdir(workdir)
             rm(workdir)
         end
-        if @isdefined server
+        if server !== nothing
             close(server)
-            rm(fpath)
+            rm(fpath; force=true)
         end
     end
 


### PR DESCRIPTION
Say I build a library and then discover that it actually depends
on Zlib. At the moment, I have to go back to the start of the
wizard and declare my additional dependency. It would be nice
to just request that the wizard add it from inside the environment.
This is what this PR implements by exposing an AF_UNIX server that
responds to requests from the sandbox.
With a suitable `bb` command, the following works from inside the sandbox:
```
sandbox:${WORKSPACE}/srcdir # bb add Zlib_jll
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Resolving package versions...
   Updating `/tmp/jl_q0IePp/mRAcrdQ3/.project/Project.toml`
  [83775a58] + Zlib_jll v1.2.11+9
   Updating `/tmp/jl_q0IePp/mRAcrdQ3/.project/Manifest.toml`
  [83775a58] + Zlib_jll v1.2.11+9
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [b77e0a4c] + InteractiveUtils
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [6462fe0b] + Sockets
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
sandbox:${WORKSPACE}/srcdir #
```

Ideally, that `bb` command, could just be a simple wrapper over
netcat. However, that runs into https://github.com/JuliaLang/julia/issues/35442.
I will add a suitable pure-C version of that BB command to the RootFS
instead. This is just the BinaryBuilder version.