### PR TITLE
Add link only flags to the gfortran wrapper

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -266,11 +266,12 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
         end
         return String[]
     end
+    gfortran_link_flags(p::Platform) = gcc_link_flags(p)
 
     # C/C++/Fortran
     gcc(io::IO, p::Platform)      = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gcc $(gcc_flags(p))"; hash_args=true, link_only_flags=gcc_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
     gxx(io::IO, p::Platform)      = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-g++ $(gcc_flags(p))"; hash_args=true, link_only_flags=gcc_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
-    gfortran(io::IO, p::Platform) = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gfortran $(fortran_flags(p))"; allow_ccache=false, unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
+    gfortran(io::IO, p::Platform) = wrapper(io, "/opt/$(aatriplet(p))/bin/$(aatriplet(p))-gfortran $(fortran_flags(p))"; allow_ccache=false, link_only_flags=gfortran_link_flags(p), unsafe_flags = allow_unsafe_flags ? String[] : ["-Ofast", "-ffast-math", "-funsafe-math-optimizations"])
     clang(io::IO, p::Platform)    = wrapper(io, "/opt/$(host_target)/bin/clang $(clang_flags(p))"; compile_only_flags=clang_compile_flags(p), link_only_flags=clang_link_flags(p))
     clangxx(io::IO, p::Platform)  = wrapper(io, "/opt/$(host_target)/bin/clang++ $(clang_flags(p))"; compile_only_flags=clang_compile_flags(p), link_only_flags=clang_link_flags(p))
     objc(io::IO, p::Platform)     = wrapper(io, "/opt/$(host_target)/bin/clang -x objective-c $(clang_flags(p))"; compile_only_flags=clang_compile_flags(p), link_only_flags=clang_link_flags(p))


### PR DESCRIPTION
We need to apply the powerpc64 fix only when linking Fortran objects.  Mathieu reported this error when trying to build HiGHS for PowerPC (see https://github.com/JuliaPackaging/Yggdrasil/pull/862):
```
[ 98%] Linking Fortran executable ../bin/fortrantest
cd /workspace/srcdir/HiGHS/build/check && /usr/bin/cmake -E cmake_link_script CMakeFiles/fortrantest.dir/link.txt --verbose=false
/opt/powerpc64le-linux-gnu/bin/../lib/gcc/powerpc64le-linux-gnu/4.8.5/../../../../powerpc64le-linux-gnu/bin/ld: warning: libpthread.so.0, needed by ../lib/libhighs.so.1.0.0, not found (try using -rpath or -rpath-link)
/opt/powerpc64le-linux-gnu/bin/../lib/gcc/powerpc64le-linux-gnu/4.8.5/../../../../powerpc64le-linux-gnu/bin/ld: warning: libdl.so.2, needed by /opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root//usr/local/lib/libgomp.so.1, not found (try using -rpath or -rpath-link)
/opt/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sys-root//usr/local/lib/libgomp.so.1: undefined reference to `pthread_key_create@GLIBC_2.17'
```