### PR TITLE
Define `GOROOT` environment variable

### DIFF
--- a/src/Runner.jl
+++ b/src/Runner.jl
@@ -300,6 +300,7 @@ function generate_compiler_wrappers!(platform::Platform; bin_path::AbstractStrin
     function go(io::IO, p::Platform)
         env = Dict(
             "GOOS" => GOOS(p),
+            "GOROOT" => "/opt/$(host_target)/go",
             "GOARCH" => GOARCH(p),
         )
         return wrapper(io, "/opt/$(host_target)/go/bin/go"; env=env, allow_ccache=false)


### PR DESCRIPTION
When trying to run CI in GitHub Actions, I got this error:

```
go: cannot find GOROOT directory: /usr/local/go1.14
```

It looks like the value of `GOROOT` comes from the host environment.  This edit
is to override a possible existing value of this environment variable.  I
determined what should have been the correct value with

```
andbox:${WORKSPACE}/srcdir # go env
[...]
GOROOT="/opt/x86_64-linux-musl/go"
[...]
```