### PR TITLE
Exit from subprocess trying to dlopen the library, instead of returning

### DIFF
--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -125,12 +125,12 @@ function audit(prefix::Prefix, src_name::AbstractString = "";
                 using Libdl
                 try
                     dlopen($(repr(f)))
-                    return 0
+                    exit(0)
                 catch e
                     if $(repr(verbose))
                         Base.display_error(e)
                     end
-                    return 1
+                    exit(1)
                 end
             """
             try


### PR DESCRIPTION
Fix #683