### PR TITLE
Compress log files in the tarball

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -30,6 +31,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
+CodecZlib = "0.5, 0.6, 0.7"
 GitHub = "5.1"
 HTTP = "0.8"
 JLD2 = "0.1.6"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -765,6 +765,9 @@ function autobuild(dir::AbstractString,
             end
         end
 
+        # Compress log files
+        compress_dir(joinpath(dest_prefix.path, "logs"), verbose=verbose)
+
         # Once we're built up, go ahead and package this dest_prefix out
         tarball_path, tarball_hash, git_hash = package(
             dest_prefix,

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -478,15 +478,18 @@ end
 
 """
     compress_dir(dir::AbstractString;
-                 compression_stream = GzipCompressorStream,
+                 compressor_stream = GzipCompressorStream,
+                 level::Int = 9,
                  extension::AbstractString = ".gz",
                  verbose::Bool = false)
 
-Compress all files in `dir` using the specified `compression_stream`, appending
-`extension` to the filenames and remove the original uncompressed files.
+Compress all files in `dir` using the specified `compressor_stream` with
+compression level equal to `level`, appending `extension` to the filenames.
+Remove the original uncompressed files at the end.
 """
 function compress_dir(dir::AbstractString;
-                      compression_stream = GzipCompressorStream,
+                      compressor_stream = GzipCompressorStream,
+                      level::Int = 9,
                       extension::AbstractString = ".gz",
                       verbose::Bool = false)
     if isdir(dir)
@@ -497,9 +500,9 @@ function compress_dir(dir::AbstractString;
             filename = joinpath(dir, f)
             if isfile(filename)
                 text = read(filename, String)
-                open(compression_stream, filename * extension, "w") do stream
-                    write(stream, text)
-                end
+                stream = compressor_stream(open(filename * extension, "w"); level=level)
+                write(stream, text)
+                close(stream)
                 rm(filename; force=true)
             end
         end


### PR DESCRIPTION
I'd like to be able to keep shipping the log files in the tarball, as they are very valuable for later debugging of the build.  Compressing them should address some complaints about their large size in the artifacts directory.