### PR TITLE
Make `get_yggdrasil` return the plain path to the local clone

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -322,7 +322,7 @@ function obtain_source(state::WizardState)
 end
 
 function get_name_and_version(state::WizardState)
-    ygg = get_yggdrasil()
+    ygg = LibGit2.GitRepo(get_yggdrasil())
 
     while state.name === nothing
         msg = "Enter a name for this project.  This will be used for filenames:"

--- a/src/wizard/yggdrasil.jl
+++ b/src/wizard/yggdrasil.jl
@@ -15,7 +15,7 @@ function get_yggdrasil()
         end
     end
     global yggdrasil_updated = true
-    return LibGit2.GitRepo(yggdrasil_dir)
+    return yggdrasil_dir
 end
 
 # We only want to update the registry once per run
@@ -73,7 +73,7 @@ end
 
 function with_yggdrasil_pr(f::Function, pr_number::Integer)
     # Get Yggdrasil, then force it to fetch our pull request refspec
-    yggy = get_yggdrasil()
+    yggy = LibGit2.GitRepo(get_yggdrasil())
 
     # First, delete any local branch that might exist with our "pr-$(pr_number)" name:
     branch_name = "pr-$(pr_number)"


### PR DESCRIPTION
Follow-up to #747: that PR changed the return type of `get_yggdrasil()`, but in `yggdrasil_deploy` we just need the path to the local clone.  I couldn't find a method of `LibGit2.clone` taking a `GitRepo` as argument, so here I'm reverting the change to the return value of `get_yggdrasil` to simply be the path to the local clone of :deciduous_tree: 