### PR TITLE
Fix warning about existing project in the wizard

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -337,12 +337,11 @@ function get_name_and_version(state::WizardState)
         if case_insensitive_repo_file_exists(ygg, yggdrasil_build_tarballs_path(new_name))
             println(state.outs, "A build recipe with that name already exists within Yggdrasil.")
 
-            if yn_prompt(state, "Choose a new project name?", :y) == :n
-                break
+            if yn_prompt(state, "Choose a new project name?", :y) != :n
+                continue
             end
-        else
-            state.name = new_name
         end
+        state.name = new_name
     end
 
     msg = "Enter a version number for this project:"

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -86,6 +86,34 @@ function call_response(ins, outs, question, answer; newline=true)
     end
 end
 
+@testset "Wizard - Obtain source" begin
+    state = BinaryBuilder.WizardState()
+    # Use a non existing name
+    with_wizard_output(state, BinaryBuilder.get_name_and_version) do ins, outs
+        call_response(ins, outs, "Enter a name for this project", "libfoobarqux")
+        call_response(ins, outs, "Enter a version number", "1.2.3")
+    end
+    @test state.name == "libfoobarqux"
+    @test state.version == v"1.2.3"
+    state.name = nothing
+    # Use an existing name, choose a new one afterwards
+    with_wizard_output(state, BinaryBuilder.get_name_and_version) do ins, outs
+        call_response(ins, outs, "Enter a name for this project", "libcurl")
+        call_response(ins, outs, "Choose a new project name", "y")
+        call_response(ins, outs, "Enter a name for this project", "libfoobarqux")
+    end
+    @test state.name == "libfoobarqux"
+    @test state.version == v"1.2.3"
+    state.name = nothing
+    # Use an existing name, confirm the choice
+    with_wizard_output(state, BinaryBuilder.get_name_and_version) do ins, outs
+        call_response(ins, outs, "Enter a name for this project", "libcurl")
+        call_response(ins, outs, "Choose a new project name", "N")
+    end
+    @test state.name == "libcurl"
+    @test state.version == v"1.2.3"
+end
+
 # Set the state up
 function step2_state()
     state = BinaryBuilder.WizardState()


### PR DESCRIPTION
As is it now, pressing "n" at the question whether you want to choose a
different name breaks the `while` loop, leaving `state.name` undefined.  We
should instead continue the loop if we say we want to choose a different name.

I even managed to write a test for this!