### PR TITLE
Throw an error if a variable name is already defined in Base

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -103,6 +103,9 @@ struct LibraryProduct <: Product
                             dir_paths::Vector{<:AbstractString}=String[];
                             dont_dlopen::Bool=false,
                             dlopen_flags::Vector{Symbol}=Symbol[])
+        if isdefined(Base, varname)
+            error("`$(varname)` is already defined in Base")
+        end
         # catch invalid flags as early as possible
         for flag in dlopen_flags
             isdefined(Libdl, flag) || error("Libdl.$flag is not a valid flag")
@@ -315,6 +318,9 @@ struct ExecutableProduct <: Product
     the `bindir` of the given `Prefix`, named one of the given `binname`s.
     """
     function ExecutableProduct(binnames::Vector{String}, varname::Symbol, dir_path::Union{AbstractString, Nothing}=nothing)
+        if isdefined(Base, varname)
+            error("`$(varname)` is already defined in Base")
+        end
         # If some other kind of AbstractString is passed in, convert it
         if dir_path != nothing
             dir_path = string(dir_path)
@@ -408,6 +414,12 @@ a `Prefix`, must simply exist to be satisfied.
 struct FileProduct <: Product
     paths::Vector{String}
     variable_name::Symbol
+    function FileProduct(paths::Vector{String}, varname::Symbol)
+        if isdefined(Base, varname)
+            error("`$(varname)` is already defined in Base")
+        end
+        return new(paths, varname)
+    end
 end
 
 FileProduct(path::AbstractString, variable_name::Symbol) = FileProduct([path], variable_name)

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -101,23 +101,34 @@ function step4(state::WizardState, ur::Runner, platform::Platform,
     println(state.outs, "Please provide a unique variable name for each build artifact:")
     for f in state.files
         default = basename(f)
-        if Base.isidentifier(default)
-            varname = line_prompt(
-                "variable name",
-                string(f, " (default '$(default)'):");
-                force_identifier=true,
-                ins=state.ins,
-                outs=state.outs,
-            )
-            isempty(varname) && (varname = default)
-        else
-            varname = nonempty_line_prompt(
-                "variable name",
-                string(f, ":");
-                force_identifier=true,
-                ins=state.ins,
-                outs=state.outs,
-            )
+        ok = false
+        varname = ""
+        while !ok
+            if Base.isidentifier(default)
+                varname = line_prompt(
+                    "variable name",
+                    string(f, " (default '$(default)'):");
+                    force_identifier=true,
+                    ins=state.ins,
+                    outs=state.outs,
+                )
+                isempty(varname) && (varname = default)
+            else
+                varname = nonempty_line_prompt(
+                    "variable name",
+                    string(f, ":");
+                    force_identifier=true,
+                    ins=state.ins,
+                    outs=state.outs,
+                )
+            end
+            if isdefined(Base, Symbol(varname))
+                printstyled(state.outs, varname,
+                            " is a symbol already defined in Base, please choose a different name\n",
+                            color=:red)
+            else
+                ok = true
+            end
         end
         push!(state.file_varnames, Symbol(varname))
     end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -95,7 +95,7 @@ end
 @testset "Products" begin
     @test_throws ErrorException LibraryProduct("sin", :sin)
     @test_throws ErrorException ExecutableProduct("convert", :convert)
-    @test_throws ErrorException FileeProduct("open", :open)
+    @test_throws ErrorException FileProduct("open", :open)
 end
 
 # Are we using docker? If so, test that the docker runner works...

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -91,6 +91,13 @@ end
     @test BinaryBuilder.exeext(Windows(:i686)) == ".exe"
 end
 
+
+@testset "Products" begin
+    @test_throws ErrorException LibraryProduct("sin", :sin)
+    @test_throws ErrorException ExecutableProduct("convert", :convert)
+    @test_throws ErrorException FileeProduct("open", :open)
+end
+
 # Are we using docker? If so, test that the docker runner works...
 @testset "Runner utilities" begin
     # Test that is_ecryptfs works for something we're certain isn't encrypted


### PR DESCRIPTION
This should alleviates issues like https://github.com/JuliaPackaging/Yggdrasil/pull/930#issuecomment-618997706, at least for symbols in Base -- at least for the version of Julia used to build the package.  I'm happy also to make this an error instead of a simple warning.