### PR TITLE
[JLL gen]: Set default value for `DYLD_FALLBACK_LIBRARY_PATH`

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1083,8 +1083,9 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                         end
                     end
                     if adjust_LIBPATH
-                        if !isempty(get(ENV, LIBPATH_env, expanduser(LIBPATH_default)))
-                            env_mapping[LIBPATH_env] = string(LIBPATH, $(repr(pathsep)), get(ENV, LIBPATH_env, expanduser(LIBPATH_default)))
+                        LIBPATH_base = get(ENV, LIBPATH_env, expanduser(LIBPATH_default))
+                        if !isempty(LIBPATH_base)
+                            env_mapping[LIBPATH_env] = string(LIBPATH, $(repr(pathsep)), LIBPATH_base)
                         else
                             env_mapping[LIBPATH_env] = LIBPATH
                         end

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1034,12 +1034,15 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
             # The LIBPATH is called different things on different platforms
             if platform isa Windows
                 LIBPATH_env = "PATH"
+                LIBPATH_default = ""
                 pathsep = ';'
             elseif platform isa MacOS
                 LIBPATH_env = "DYLD_FALLBACK_LIBRARY_PATH"
+                LIBPATH_default = "~/lib:/usr/local/lib:/lib:/usr/lib"
                 pathsep = ':'
             else
                 LIBPATH_env = "LD_LIBRARY_PATH"
+                LIBPATH_default = ""
                 pathsep = ':'
             end
 
@@ -1048,6 +1051,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
             PATH = ""
             LIBPATH = ""
             LIBPATH_env = $(repr(LIBPATH_env))
+            LIBPATH_default = $(repr(LIBPATH_default))
             """)
 
             # Next, begin placing products
@@ -1079,7 +1083,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                         end
                     end
                     if adjust_LIBPATH
-                        if !isempty(get(ENV, LIBPATH_env, ""))
+                        if !isempty(get(ENV, LIBPATH_env, expanduser(LIBPATH_default)))
                             env_mapping[LIBPATH_env] = string(LIBPATH, $(repr(pathsep)), ENV[LIBPATH_env])
                         else
                             env_mapping[LIBPATH_env] = LIBPATH

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1084,7 +1084,7 @@ function build_jll_package(src_name::String, build_version::VersionNumber, code_
                     end
                     if adjust_LIBPATH
                         if !isempty(get(ENV, LIBPATH_env, expanduser(LIBPATH_default)))
-                            env_mapping[LIBPATH_env] = string(LIBPATH, $(repr(pathsep)), ENV[LIBPATH_env])
+                            env_mapping[LIBPATH_env] = string(LIBPATH, $(repr(pathsep)), get(ENV, LIBPATH_env, expanduser(LIBPATH_default)))
                         else
                             env_mapping[LIBPATH_env] = LIBPATH
                         end


### PR DESCRIPTION
Simon Byrne reported that on MacOS 10.13-, setting
`DYLD_FALLBACK_LIBRARY_PATH` failed to load `libc++`, which is referred
to by `@rpath/libc++.dylib` by `libLLVM`.  This is most likely because
these older MacOSs have a default `DYLD_FALLBACK_LIBRARY_PATH` that gets
overridden, and the new value searches for `libc++.dylib`
unsuccessfully.