### PR TITLE
Do not write platforms to JSON if building for AnyPlatform

### DIFF
--- a/src/Declarative.jl
+++ b/src/Declarative.jl
@@ -51,8 +51,14 @@ function cleanup_merged_object!(meta::Dict)
     end
     meta["products"] = Product[reconstruct_product(p) for p in meta["products"]]
 
-    # Convert platforms back to actual Platform objects
-    meta["platforms"] = [platform_key_abi(p) for p in meta["platforms"]]
+    if haskey(meta, "platform")
+        # Convert platforms back to actual Platform objects
+        meta["platforms"] = [platform_key_abi(p) for p in meta["platforms"]]
+    else
+        # If the key isn't there it's because this is a platform-independent
+        # build, so use `AnyPlatform()`.
+        meta["platforms"] = [AnyPlatform()]
+    end
 
     # Return the cleaned-up meta for fun
     return meta


### PR DESCRIPTION
The platform will be brought back when cleaning up the merged objects.

Also, we need to special-case `platform_key_abi("any")` in `build_tarballs()`.