### PR TITLE
Fix isolated dlopen

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -195,7 +195,7 @@ function locate(lp::LibraryProduct, prefix::Prefix; platform::Platform = platfor
                     if (!lp.dont_dlopen && !skip_dlopen) && platforms_match(platform, platform_key_abi())
                         if isolate
                             # Isolated dlopen is a lot slower, but safer
-                            if success(`$(Base.julia_cmd()) -e "import Libdl; Libdl.dlopen(\"$dl_path\")"`)
+                            if success(`$(Base.julia_cmd()) --startup-file=no -e "import Libdl; Libdl.dlopen(\"$dl_path\")"`)
                                 return dl_path
                             end
                         else


### PR DESCRIPTION
In `locate`, when launching an external Julia to test whether dlopen work
on a library, pass `--startup-file=no` to the subprocess to avoid any issues
with commands in a user's startup.jl file.


While I don't know a specific bug this causes, in the corresponding code in
BinaryProvider it triggered a [very annoying and difficult to debug issue](https://github.com/JuliaPackaging/BinaryProvider.jl/pull/195), so
better be safe than sorry?
