### PR TITLE
Ask to the user to accept macOS SDK during wizard

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -250,6 +250,22 @@ function step1(state::WizardState)
         error("Somehow platform_select was not a valid choice!")
     end
 
+    global automatic_apple
+    if any(p -> p isa MacOS, state.platforms) && !automatic_apple && !macos_sdk_already_installed()
+        # Ask the user if they accept to download the macOS SDK
+        automatic_apple = accept_apple_sdk(state.ins, state.outs)
+        if !automatic_apple
+            # The user refused to download the macOS SDK
+            println(state.outs)
+            printstyled(state.outs, "Removing MacOS from the list of platforms...\n", bold=true)
+            filter!(p -> !isa(p, MacOS), state.platforms)
+        end
+    end
+    if isempty(state.platforms)
+        # In case the user didn't accept the macOS SDK and macOS was the only
+        # platform selected.
+        error("No valid platform selected!")
+    end
     println(state.outs)
 end
 


### PR DESCRIPTION
This avoids crashing the wizard badly if the user doesn't accept the terms of
the SDK.

Fix #770