### PR TITLE
Add new constructor for `LibProduct`

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -99,6 +99,7 @@ struct LibraryProduct <: Product
     `dlopen()`'able.
     """
     LibraryProduct(libname::AbstractString, varname, args...; kwargs...) = LibraryProduct([libname], varname, args...; kwargs...)
+    LibraryProduct(libnames::Vector{<:AbstractString}, varname::Symbol, dir_path::AbstractString, args...; kwargs...) = LibraryProduct(libnames, varname, [dir_path], args...; kwargs...)
     function LibraryProduct(libnames::Vector{<:AbstractString}, varname::Symbol,
                             dir_paths::Vector{<:AbstractString}=String[];
                             dont_dlopen::Bool=false,

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -109,6 +109,12 @@ end
 
 
 @testset "Products" begin
+    lp = LibraryProduct("libfakechroot", :libfakechroot, "lib/fakechroot")
+    @test lp.libnames ==  ["libfakechroot"]
+    @test lp.dir_paths == ["lib/fakechroot"]
+    ep = ExecutableProduct("fooify", :fooify, "bin/foo_inc")
+    @test ep.binnames ==  ["fooify"]
+
     @test_throws ErrorException LibraryProduct("sin", :sin)
     @test_throws ErrorException ExecutableProduct("convert", :convert)
     @test_throws ErrorException FileProduct("open", :open)


### PR DESCRIPTION
This allows passing both `libnames` and `dir_paths` as lone strings, as it is
done by the wizard.

Fix #813