### PR TITLE
Move Julia's libdirs to the end of `LIBPATH_list` in JLL packages

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1150,8 +1150,6 @@ function build_jll_package(src_name::String,
 
                 # Initialize PATH and LIBPATH environment variable listings
                 global PATH_list, LIBPATH_list
-                # We first need to add to LIBPATH_list the libraries provided by Julia
-                append!(LIBPATH_list, [$(init_libpath)])
             """)
 
             if !isempty(dependencies)
@@ -1162,6 +1160,11 @@ function build_jll_package(src_name::String,
                     foreach(p -> append!(LIBPATH_list, p), ($(join(["$(getname(dep)).LIBPATH_list" for dep in dependencies], ", ")),))
                 """)
             end
+
+            print(io, """
+                # Lastly, we need to add to LIBPATH_list the libraries provided by Julia
+                append!(LIBPATH_list, [$(init_libpath)])
+            """)
 
             for (p, p_info) in sort(products_info)
                 vp = variable_name(p)


### PR DESCRIPTION
This should fix issues in `Git_jll` where `git` requires a particular
version of `libpcre2-8.dylib`; the changes within that libcpre are
backwards-incompatible without changing the SONAME.

In general however, we want executables within JLL packages to get as
close of a view of their build environment as possible, so we should
prioritize JLL package libraries over those sitting in Julia's libdir.