### PR TITLE
Automatically remove `_jll` from name of project in Wizard

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -342,7 +342,9 @@ function get_name_and_version(state::WizardState)
 
     while state.name === nothing
         msg = "Enter a name for this project.  This will be used for filenames:"
-        new_name = nonempty_line_prompt("Name", msg; ins=state.ins, outs=state.outs)
+        # Remove trailing `_jll` in case the user thinks this should be part of the name
+        new_name = replace(nonempty_line_prompt("Name", msg; ins=state.ins, outs=state.outs),
+                           r"_jll$" => "")
 
         if !Base.isidentifier(new_name)
             println(state.outs, "\"$(new_name)\" is an invalid identifier. Try again.")

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -90,7 +90,8 @@ end
     state = Wizard.WizardState()
     # Use a non existing name
     with_wizard_output(state, Wizard.get_name_and_version) do ins, outs
-        call_response(ins, outs, "Enter a name for this project", "libfoobarqux")
+        # Append "_jll" to the name and make sure this is automatically removed
+        call_response(ins, outs, "Enter a name for this project", "libfoobarqux_jll")
         call_response(ins, outs, "Enter a version number", "1.2.3")
     end
     @test state.name == "libfoobarqux"


### PR DESCRIPTION
This avoids issues like https://github.com/JuliaPackaging/Yggdrasil/pull/1266