### PR TITLE
Add to the JLLs a function to tell whether the current platform is supported

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1121,6 +1121,9 @@ function build_jll_package(src_name::String,
             end
 
             print(io, """
+            # Inform that the wrapper is available for this platform
+            is_available() = tue
+
             \"\"\"
             Open all libraries
             \"\"\"
@@ -1214,6 +1217,13 @@ function build_jll_package(src_name::String,
 
         using Pkg, Pkg.BinaryPlatforms, Pkg.Artifacts, Libdl
         import Base: UUID
+
+        \"\"\"
+            is_available()
+
+        Return whether the artifact is available for the current platform.
+        \"\"\"
+        is_available() = false
 
         # We put these inter-JLL-package API values here so that they are always defined, even if there
         # is no underlying wrapper held within this JLL package.

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1122,7 +1122,7 @@ function build_jll_package(src_name::String,
 
             print(io, """
             # Inform that the wrapper is available for this platform
-            is_available() = tue
+            is_available() = true
 
             \"\"\"
             Open all libraries

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -134,6 +134,7 @@ end
             Pkg.develop(PackageSpec(path=code_dir))
             @eval TestJLL using libfoo_jll
             @test 6.08 ≈ @eval TestJLL ccall((:foo, libfoo), Cdouble, (Cdouble, Cdouble), 2.3, 4.5)
+            @test @eval TestJLL libfoo_jll.is_available()
         end
     end
 end


### PR DESCRIPTION
Happy to receive better suggestions for the name of the function.

TODO:

* [ ] Mention this function in the documentation of the JLL wrappers

CC: @fingolfin 