### PR TITLE
Pass credentials to Libgit2.fetch in init_jll_package

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1382,19 +1382,13 @@ function push_jll_package(name, build_version;
     wrapper_repo = LibGit2.GitRepo(code_dir)
     LibGit2.add!(wrapper_repo, ".")
     LibGit2.commit(wrapper_repo, "$(name)_jll build $(build_version)")
-    creds = LibGit2.UserPasswordCredential(
-        deepcopy(gh_username),
-        deepcopy(gh_auth.token),
-    )
-    try
+    Wizard.with_gitcreds(gh_username, gh_auth.token) do creds
         LibGit2.push(
             wrapper_repo;
             refspecs=["refs/heads/master"],
             remoteurl="https://github.com/$(deploy_repo).git",
             credentials=creds,
         )
-    finally
-        Base.shred!(creds)
     end
 end
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -860,7 +860,15 @@ function init_jll_package(name, code_dir, deploy_repo;
     else
         # Otherwise, hard-reset to latest master:
         repo = LibGit2.GitRepo(code_dir)
-        LibGit2.fetch(repo)
+        creds = LibGit2.UserPasswordCredential(
+            deepcopy(gh_username),
+            deepcopy(gh_auth.token),
+        )
+        try
+            LibGit2.fetch(repo; credentials=creds)
+        finally
+            Base.shred!(creds)
+        end
         origin_master_oid = LibGit2.GitHash(LibGit2.lookup_branch(repo, "origin/master", true))
         LibGit2.reset!(repo, origin_master_oid, LibGit2.Consts.RESET_HARD)
         if string(LibGit2.head_oid(repo)) != string(origin_master_oid)

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -848,26 +848,14 @@ function init_jll_package(name, code_dir, deploy_repo;
     if !isdir(code_dir)
         # If it does exist, clone it down:
         @info("Cloning wrapper code repo from https://github.com/$(deploy_repo) into $(code_dir)")
-        creds = LibGit2.UserPasswordCredential(
-            deepcopy(gh_username),
-            deepcopy(gh_auth.token),
-        )
-        try
+        Wizard.with_gitcreds(gh_username, gh_auth.token) do creds
             LibGit2.clone("https://github.com/$(deploy_repo)", code_dir; credentials=creds)
-        finally
-            Base.shred!(creds)
         end
     else
         # Otherwise, hard-reset to latest master:
         repo = LibGit2.GitRepo(code_dir)
-        creds = LibGit2.UserPasswordCredential(
-            deepcopy(gh_username),
-            deepcopy(gh_auth.token),
-        )
-        try
+        Wizard.with_gitcreds(gh_username, gh_auth.token) do creds
             LibGit2.fetch(repo; credentials=creds)
-        finally
-            Base.shred!(creds)
         end
         origin_master_oid = LibGit2.GitHash(LibGit2.lookup_branch(repo, "origin/master", true))
         LibGit2.reset!(repo, origin_master_oid, LibGit2.Consts.RESET_HARD)

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -127,8 +127,8 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         deploy_bin_repo = deploy_repo
         deploy_jll_repo = deploy_repo
     elseif deploy_bin # make sure bin repo and jll repo match
-        deploy_jll_repo = deploy_bin_repo 
-    elseif deploy_jll 
+        deploy_jll_repo = deploy_bin_repo
+    elseif deploy_jll
         deploy_bin_repo = deploy_jll_repo
     elseif deploy_bin && deploy_jll
         if deploy_bin_repo != deploy_jll_repo
@@ -326,7 +326,7 @@ function get_compilers_versions(; compilers = [:c])
     return output
 end
 
-function upload_to_github_releases(repo, tag, path; gh_auth=Wizard.github_auth(;allow_anonymous=false), 
+function upload_to_github_releases(repo, tag, path; gh_auth=Wizard.github_auth(;allow_anonymous=false),
                                    attempts::Int = 3, verbose::Bool = false)
     for attempt in 1:attempts
         try
@@ -1190,11 +1190,11 @@ function build_jll_package(src_name::String,
     # Generate target-demuxing main source file.
     jll_jl = """
         module $(src_name)_jll
-        
+
         if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
             @eval Base.Experimental.@optlevel 0
-        end                    
-                                
+        end
+
         if VERSION < v"1.3.0-rc4"
             # We lie a bit in the registry that JLL packages are usable on Julia 1.0-1.2.
             # This is to allow packages that might want to support Julia 1.0 to get the

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -174,11 +174,7 @@ function yggdrasil_deploy(name, version, patches, build_tarballs_content; open_p
         @info("Committing and pushing to $(fork.full_name)#$(branch_name)...")
         LibGit2.add!(repo, rel_bt_path)
         LibGit2.commit(repo, "New Recipe: $(name) v$(version)")
-        creds = LibGit2.UserPasswordCredential(
-            dirname(fork.full_name),
-            deepcopy(gh_auth.token)
-        )
-        try
+        with_gitcreds(gh_username, gh_auth.token) do creds
             LibGit2.push(
                 repo,
                 refspecs=["+HEAD:refs/heads/$(branch_name)"],
@@ -188,8 +184,6 @@ function yggdrasil_deploy(name, version, patches, build_tarballs_content; open_p
                 # refspec: https://github.com/JuliaLang/julia/issues/23057
                 #force=true,
             )
-        finally
-            Base.shred!(creds)
         end
 
         if open_pr

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -254,3 +254,25 @@ function print_wizard_logo(outs)
     )
     println(outs)
 end
+
+"""
+    with_gitcreds(f, username::AbstractString, password::AbstractString)
+
+Calls `f` with an `LibGit2.UserPasswordCredential` object as an argument, constructed from
+the `username` and `password` values. `with_gitcreds` ensures that the credentials object
+gets properly shredded after it's no longer necessary. E.g.:
+
+```julia
+with_gitcreds(user, token) do creds
+    LibGit2.clone("https://github.com/foo/bar.git", "bar"; credentials=creds)
+end
+````
+"""
+function with_gitcreds(f, username::AbstractString, password::AbstractString)
+    creds = LibGit2.UserPasswordCredential(deepcopy(username), deepcopy(password))
+    try
+        f(creds)
+    finally
+        Base.shred!(creds)
+    end
+end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -202,7 +202,7 @@ end
     dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
     @test dict["compat"]["julia"] == "1.0"
     @test dict["compat"]["libLLVM_jll"] == "=9.0.0"
-    
+
     dependencies = [
         Dependency(PackageSpec(name="libLLVM_jll", version="8.3-10")),
     ]


### PR DESCRIPTION
I am playing around with BinaryBuilder and private repos. Specifically, trying to update an existing _private_ jll repo. The `git fetch` step here asks for username & password, even though I am using `ENV["GITHUB_TOKEN"]`.

Passing the credentials to `fetch` (like is done for `clone` just a few lines before) would make sense to me. It seems to fix it for my use-case, but I haven't tested it beyond that.