### PR TITLE
Include build_tarballs --help text in the manual

### DIFF
--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -32,7 +32,7 @@ Remember also that you should use the standard environment variables like `CC`, 
 
 ### I love the wizard, but now I want to break free: can I build the tarballs without it?
 
-The `build_tarballs.jl` script can be used as a command line utility, it takes a few options and as argument the list of triplets of the targets.  You can find more information about the syntax of the script with
+The `build_tarballs.jl` script can be used as a command line utility, it takes a few options and as argument the list of triplets of the targets.  You can find more information about the syntax of the script in the [Command Line](@ref) section or by running
 ```
 julia build_tarballs.jl --help
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -10,4 +10,23 @@ Order = [:type]
 ```@autodocs
 Modules = [BinaryBuilderBase, BinaryBuilder, BinaryBuilder.Auditor, BinaryBuilder.Wizard]
 Order = [:function]
+# We'll include build_tarballs explicitly below, so let's exclude it here:
+Filter = x -> !(isa(x, Function) && x === build_tarballs)
 ```
+
+## Command Line
+```@docs
+build_tarballs
+```
+
+The [`build_tarballs`](@ref) function also parses command line arguments. The syntax is
+described in the `--help` output:
+
+````@eval
+using BinaryBuilder, Markdown
+Markdown.parse("""
+```
+$(BinaryBuilder.BUILD_HELP)
+```
+""")
+````

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -73,9 +73,12 @@ This should be the top-level function called from a `build_tarballs.jl` file.
 It takes in the information baked into a `build_tarballs.jl` file such as the
 `sources` to download, the `products` to build, etc... and will automatically
 download, build and package the tarballs, generating a `build.jl` file when
-appropriate.  Note that `ARGS` should be the top-level Julia `ARGS` command-
-line arguments object.  This function does some rudimentary parsing of the
-`ARGS`, call it with `--help` in the `ARGS` to see what it can do.
+appropriate.
+
+Generally, `ARGS` should be the top-level Julia `ARGS` command-line arguments
+object.  `build_tarballs` does some rudimentary parsing of the arguments. To
+see what it can do, you can call it with `--help` in the `ARGS` or see the
+[Command Line](@ref) section in the manual.
 
 The `kwargs` are passed on to [`autobuild`](@ref), see there for a list of
 supported ones. In addition, the keyword argument `init_block` may be set to


### PR DESCRIPTION
Moves the `build_tarballs` docstring a bit down in the manual and puts the `--help` text right after it. It will render as a code block, so unfortunately won't be searchable, but still better than not having it at all I think.