### PR TITLE
build_tarballs: fix call to get_meta_json

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -224,12 +224,11 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         # Dependencies that must be downloaded
         dependencies,
     )
+    extra_kwargs = extract_kwargs(kwargs, (:lazy_artifacts, :init_block))
 
     if meta_json_stream !== nothing
         # If they've asked for the JSON metadata, by all means, give it to them!
-        dict = get_meta_json(args...;
-                             lazy_artifacts = lazy_artifacts,
-                             init_block = init_block)
+        dict = get_meta_json(args...; extra_kwargs...)
         println(meta_json_stream, JSON.json(dict))
 
         if meta_json_stream !== stdout
@@ -264,9 +263,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         # The location the binaries will be available from
         bin_path = "https://github.com/$(deploy_jll_repo)/releases/download/$(tag)"
         build_jll_package(src_name, build_version, sources, code_dir, build_output_meta,
-                          dependencies, bin_path; verbose=verbose,
-                          extract_kwargs(kwargs, (:lazy_artifacts, :init_block))...,
-                          )
+                          dependencies, bin_path; verbose=verbose, extra_kwargs...)
         if deploy_jll_repo != "local"
             push_jll_package(src_name, build_version; code_dir=code_dir, deploy_repo=deploy_jll_repo)
         end


### PR DESCRIPTION
Oops, I screwed up in PR #872 -- this hopefully fixes it. I only noticed it when I wanted to add a `julia_dependencies` kwarg... I hope I got it right now. It's a bit frightening that there is no test for `build_tarballs()` in there at all, though... Perhaps at least the variant with `--meta-json` could be tested, which likely would have caught this one?

I also wonder if perhaps @staticfloat's work in #861 can be used to test (in the test suite) the generation of a full JLL, locally, by outputting it into a temporary directory; and then perhaps `diff` could be used to compare it to a pregenerated copy, so that any changes are detected. (Of course one could then also repeat this with different settings used).