### PR TITLE
Add julia_compat keyword argument to build_tarballs

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -6,6 +6,8 @@ using RegistryTools, Registrator
 import LibGit2
 import PkgLicenses
 
+const DEFAULT_JULIA_VERSION_SPEC = "1.0"
+
 const BUILD_HELP = (
     """
     Usage: build_tarballs.jl [target1,target2,...] [--help]
@@ -84,6 +86,10 @@ see what it can do, you can call it with `--help` in the `ARGS` or see the
 
 The `kwargs` are passed on to [`autobuild`](@ref), see there for a list of
 supported ones. A few additional keyword arguments are accept:
+
+* `julia_compat` can be set to a version string which is used to set the
+  supported Julia version in the `[compat]` section of the `Project.toml` of
+  the generated JLL package. The default value is `"1.0"`.
 
 * `lazy_artifacts` sets whether the artifacts should be lazy.
 
@@ -224,7 +230,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         # Dependencies that must be downloaded
         dependencies,
     )
-    extra_kwargs = extract_kwargs(kwargs, (:lazy_artifacts, :init_block))
+    extra_kwargs = extract_kwargs(kwargs, (:julia_compat, :lazy_artifacts, :init_block))
 
     if meta_json_stream !== nothing
         # If they've asked for the JSON metadata, by all means, give it to them!
@@ -272,7 +278,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
                 @info("Registering new wrapper code version $(build_version)...")
             end
 
-            register_jll(src_name, build_version, dependencies;
+            register_jll(src_name, build_version, dependencies, julia_compat;
                             deploy_repo=deploy_jll_repo, code_dir=code_dir)
         end
     end
@@ -427,7 +433,7 @@ function _package_is_registered(registry_url::AbstractString,
     return package in registered_packages
 end
 
-function register_jll(name, build_version, dependencies;
+function register_jll(name, build_version, dependencies, julia_compat;
                       deploy_repo="JuliaBinaryWrappers/$(name)_jll.jl",
                       code_dir=joinpath(Pkg.devdir(), "$(name)_jll"),
                       gh_auth=Wizard.github_auth(;allow_anonymous=false),
@@ -443,7 +449,7 @@ function register_jll(name, build_version, dependencies;
     cache = RegistryTools.RegistryCache(joinpath(Pkg.depots1(), "registries_binarybuilder"))
     registry_url = "https://$(gh_username):$(gh_auth.token)@github.com/JuliaRegistries/General"
     cache.registries[registry_url] = Base.UUID("23338594-aafe-5451-b93e-139f81909106")
-    project = Pkg.Types.Project(build_project_dict(name, build_version, dependencies))
+    project = Pkg.Types.Project(build_project_dict(name, build_version, dependencies, julia_compat))
     errors = setdiff(RegistryTools.registrator_errors, [:version_less_than_all_existing])
     reg_branch = RegistryTools.register(
         "https://github.com/$(deploy_repo).git",
@@ -490,6 +496,7 @@ function get_meta_json(
                    platforms::Vector,
                    products::Vector{<:Product},
                    dependencies::Vector{<:AbstractDependency};
+                   julia_compat::String = DEFAULT_JULIA_VERSION_SPEC,
                    lazy_artifacts::Bool = false,
                    init_block::String = "")
 
@@ -500,6 +507,7 @@ function get_meta_json(
         "script" => script,
         "products" => products,
         "dependencies" => dependencies,
+        "julia_compat" => julia_compat,
         "lazy_artifacts" => lazy_artifacts,
         "init_block" => init_block,
     )
@@ -926,6 +934,7 @@ function rebuild_jll_package(obj::Dict;
         upload_prefix;
         verbose=verbose,
         lazy_artifacts = lazy_artifacts,
+        julia_compat = get(obj, "julia_compat", DEFAULT_JULIA_VERSION_SPEC),
         init_block = get(obj, "init_block", ""),
         from_scratch = from_scratch,
     )
@@ -935,8 +944,8 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
                              platforms::Vector, products::Vector, dependencies::Vector,
                              download_dir::String, upload_prefix::String;
                              code_dir::String = joinpath(Pkg.devdir(), "$(name)_jll"),
-                             verbose::Bool = false, lazy_artifacts::Bool = false,
-                             init_block::String = "", from_scratch::Bool = true)
+                             verbose::Bool = false, from_scratch::Bool = true,
+                             kwargs...)
     # We're going to recreate "build_output_meta"
     build_output_meta = Dict()
 
@@ -999,7 +1008,7 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
         # Finally, generate the full JLL package
         build_jll_package(name, build_version, sources, code_dir, build_output_meta,
                           dependencies, upload_prefix; verbose=verbose,
-                          lazy_artifacts=lazy_artifacts, init_block=init_block)
+                          kwargs...)
     end
 end
 
@@ -1011,6 +1020,7 @@ function build_jll_package(src_name::String,
                            dependencies::Vector,
                            bin_path::String;
                            verbose::Bool = false,
+                           julia_compat::String = DEFAULT_JULIA_VERSION_SPEC,
                            lazy_artifacts::Bool = false,
                            init_block = "")
     if !Base.isidentifier(src_name)
@@ -1441,7 +1451,7 @@ function build_jll_package(src_name::String,
     rm(joinpath(code_dir, "LICENSE.md"); force=true)
 
     # Add a Project.toml
-    project = build_project_dict(src_name, build_version, dependencies)
+    project = build_project_dict(src_name, build_version, dependencies, julia_compat)
     open(joinpath(code_dir, "Project.toml"), "w") do io
         Pkg.TOML.print(io, project)
     end
@@ -1483,7 +1493,7 @@ const uuid_package = UUID("cfb74b52-ec16-5bb7-a574-95d9e393895e")
 # For even more interesting historical reasons, we append an extra
 # "_jll" to the name of the new package before computing its UUID.
 jll_uuid(name) = bb_specific_uuid5(uuid_package, "$(name)_jll")
-function build_project_dict(name, version, dependencies::Array{Dependency})
+function build_project_dict(name, version, dependencies::Array{Dependency}, julia_compat::String=DEFAULT_JULIA_VERSION_SPEC)
     function has_compat_info(d::Dependency)
         r = Pkg.Types.VersionRange()
         return isa(d.pkg.version, VersionNumber) ||
@@ -1501,14 +1511,15 @@ function build_project_dict(name, version, dependencies::Array{Dependency})
        return string(v)
     end
     exactly_this_version(v) = v
+    Pkg.Types.semver_spec(julia_compat) # verify julia_compat is valid
     project = Dict(
         "name" => "$(name)_jll",
         "uuid" => string(jll_uuid("$(name)_jll")),
         "version" => string(version),
         "deps" => Dict{String,Any}(),
         # We require at least Julia 1.3+, for Pkg.Artifacts support, but we only claim
-        # Julia 1.0+ so that empty JLLs can be installed on older versions.
-        "compat" => Dict{String,Any}("julia" => "1.0")
+        # Julia 1.0+ by default so that empty JLLs can be installed on older versions.
+        "compat" => Dict{String,Any}("julia" => "$(julia_compat)")
     )
     for dep in dependencies
         depname = getname(dep)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -195,6 +195,15 @@ end
     @test next_version.minor == version.minor
     @test next_version.patch == version.patch
 
+    # Ensure passing a Julia dependency bound works
+    dict = build_project_dict(name, version, dependencies, "1.4")
+    @test dict["compat"] == Dict{String,Any}("julia" => "1.4")
+
+    dict = build_project_dict(name, version, dependencies, "~1.4")
+    @test dict["compat"] == Dict{String,Any}("julia" => "~1.4")
+
+    @test_throws ErrorException build_project_dict(name, version, dependencies, "nonsense")
+
     # Ensure passing compat bounds works
     dependencies = [
         Dependency(PackageSpec(name="libLLVM_jll", version=v"9")),


### PR DESCRIPTION
Resolves #856

I ended up using a plain string for the `julia_compat` argument, which is written unchanged into the `Project.toml` (however, it gets validated before, so the user can't insert invalid version specifiers). My first prototype used `Pkg.Types.VersionSpec`, but I moved away from that for several reasons:

1. As far as I can tell, `Pkg.Types.VersionSpec` is completely undocumented
2. Julia package developers are used to compat strings like `"~1.4"`; but they can't use that directly with `Pkg.Types.VersionSpec`; not everybody will now (or find intuitive) that  "~1.4" needs to be entered as `"1.4.0 - 1.4"`, or `"^1.4"` as `"1.4.0 - 1"`
3. One can ease this by using `Pkg.Types.semver_spec` but again that's completely undocumented (I still use it in this PR to validate the version specifier provided by the user, though)
4. Even if one uses `Pkg.Types.semver_spec`, after serializing and deserializing something like `Pkg.Types.semver_spec("~1.4")` one ends up with a `[compat]` entry of the form `julia = "1.4.0 - 1.4"`, and I also dislike it there, as people reading the `Project.toml` may not be used to it. Certainly this point can be argued about most (the package registry seems to prefer these "normalized" version ranges).

Regarding the name `julia_compat`, here are some alternatives I considered:
1. `julia_dependency` is what I originally used (still appears in the branch name for this PR) and was originally [suggested by @staticfloat in a comment](https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/511#issuecomment-634974371); in that original suggestion, the name made sense, because the idea was to pass in something like `Pkg.Types.PackageSpec(name="julia", version=Pkg.Types.VersionSpec("1.0"))`. But since then I decided to change away from `PackageSpec` (as that seemed needlessly redundant). In the end, the content of the new parameter is sufficiently different from what's stored in `dependencies`, so I felt that calling it `julia_dependency` would be potentially confusing and misleading
2. `julia_version` -- this is not just a version in general, but a version *spec*
3. `julia_versionspec` -- would make sense if the content was really a `Pkg.Types.VersionSpec`, but I feel it's a bit misleading if it's just a string
4. `julia_compat` is what I finally settled on, as this is the Julia entry in the `[compat]` section
5. `compat_julia` would certainly be another alternative, but I wanted to get the bikeshed ready; it's easy to repaint it now if people want to :-)


I've decided this with `--deploy=local` and it worked there.


Of course now that I've written it, I am not completely sure anymore this is the way to move forward: for my usecase, and likely also that of @barche for CxxWrap.jl, it would actually be better if the Julia version was part of the "platform triplet" ("platform tuple"???) because we both really want a single JLL, just with different binaries for different Julia platforms. 
However, I have no idea how to get started on that...
