### PR TITLE
Import JSON in Wizard

### DIFF
--- a/src/Wizard.jl
+++ b/src/Wizard.jl
@@ -3,6 +3,7 @@ module Wizard
 using BinaryBuilderBase, OutputCollectors, ..Auditor
 using Random
 using GitHub, LibGit2, Pkg, Sockets, ObjectFile
+using JSON
 import SHA: sha256
 using REPL
 using REPL.Terminals


### PR DESCRIPTION
`Wizard.jl` did not import `JSON` package, failing at successfully obtaining token:

```
ERROR: LoadError: UndefVarError: JSON not defined
Stacktrace:
 [1] obtain_token(; ins::Base.TTY, outs::Base.TTY, github_api::GitHub.GitHubWebAPI) at /home/pxl_th/.julia/dev/BinaryBuilder/src/wizard/github.jl:89
 [2] obtain_token() at /home/pxl_th/.julia/dev/BinaryBuilder/src/wizard/github.jl:31
 [3] github_auth(; allow_anonymous::Bool) at /home/pxl_th/.julia/dev/BinaryBuilder/src/wizard/github.jl:18
 [4] init_jll_package(::String, ::String, ::SubString{String}) at /home/pxl_th/.julia/dev/BinaryBuilder/src/AutoBuild.jl:828
 [5] build_tarballs(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any; kwargs::Any) at /home/pxl_th/.julia/dev/BinaryBuilder/src/AutoBuild.jl:195
 [6] top-level scope at /home/pxl_th/projects/Assimp.jl/assimp_win_master/build_tarballs.jl:44
 [7] include(::Function, ::Module, ::String) at ./Base.jl:380
 [8] include(::Module, ::String) at ./Base.jl:368
 [9] exec_options(::Base.JLOptions) at ./client.jl:296
 [10] _start() at ./client.jl:506

```