### PR TITLE
WIP 1.6 Artifacts JLL generation

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1336,7 +1336,7 @@ function build_jll_package(src_name::String,
     if Set(platforms) == Set([AnyPlatform()])
         # We know directly the wrapper we want to include
         jll_jl *= """
-            Core.include(@__MODULE__, joinpath(@__DIR__, "wrappers", "any.jl"))
+            Base.include(@__MODULE__, joinpath(@__DIR__, "wrappers", "any.jl"))
             """
     else
         jll_jl *= """
@@ -1352,7 +1352,7 @@ function build_jll_package(src_name::String,
             if best_wrapper === nothing
                 @debug("Unable to load $(src_name); unsupported platform \$(triplet(platform_key_abi()))")
             else
-                Core.include($(src_name)_jll, best_wrapper)
+                Base.include($(src_name)_jll, best_wrapper)
             end
             """
     end

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -375,11 +375,6 @@ function upload_to_github_releases(repo, tag, path; gh_auth=Wizard.github_auth(;
     error("Unable to upload $(path) to GitHub repo $(repo) on tag $(tag)")
 end
 
-# Julia 1.3- needs a compat shim here
-if VERSION < v"1.4-"
-    Pkg.Operations.registered_paths(ctx::Pkg.Types.Context, uuid::UUID) = Pkg.Operations.registered_paths(ctx.env, uuid)
-end
-
 function get_next_wrapper_version(src_name, src_version)
     # If src_version already has a build_number, just return it immediately
     if src_version.build != ()

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1068,132 +1068,63 @@ function build_jll_package(src_name::String,
                 println(io, "using $(getname(dep))")
             end
 
-            # The LIBPATH is called different things on different platforms
-            if platform isa Windows
-                LIBPATH_env = "PATH"
-                LIBPATH_default = ""
-                pathsep = ';'
-            elseif platform isa MacOS
-                LIBPATH_env = "DYLD_FALLBACK_LIBRARY_PATH"
-                LIBPATH_default = "~/lib:/usr/local/lib:/lib:/usr/lib"
-                pathsep = ':'
-            else
-                LIBPATH_env = "LD_LIBRARY_PATH"
-                LIBPATH_default = ""
-                pathsep = ':'
-            end
-
-            println(io, """
-            ## Global variables
-            PATH = ""
-            LIBPATH = ""
-            LIBPATH_env = $(repr(LIBPATH_env))
-            LIBPATH_default = $(repr(LIBPATH_default))
-            """)
-
             # Next, begin placing products
             function global_declaration(p::LibraryProduct, p_info::Dict)
-                # A library product's public interface is a handle
-                return """
-                # This will be filled out by __init__()
-                $(variable_name(p))_handle = C_NULL
-
-                # This must be `const` so that we can use it with `ccall()`
-                const $(variable_name(p)) = $(repr(p_info["soname"]))
-                """
+                return "JLLWrappers.@declare_library_product($(variable_name(p)), $(repr(p_info["soname"])))"
             end
-
             global_declaration(p::FrameworkProduct, p_info::Dict) = global_declaration(p.libraryproduct, p_info)
 
             function global_declaration(p::ExecutableProduct, p_info::Dict)
                 vp = variable_name(p)
                 # An executable product's public interface is a do-block wrapper function
-                return """
-                $(vp)(f::Function; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true) =
-                    executable_wrapper(f, $(vp)_path, PATH, LIBPATH, LIBPATH_env, LIBPATH_default, adjust_PATH, adjust_LIBPATH, ':')
-                """
+                return "JLLWrappers.@declare_executable_product($(variable_name(p)))"
             end
 
             function global_declaration(p::FileProduct, p_info::Dict)
-                return """
-                # This will be filled out by __init__()
-                $(variable_name(p)) = ""
-                """
+                return "JLLWrappers.@declare_file_product($(variable_name(p)))"
             end
 
             # Create relative path mappings that are compile-time constant, and mutable
             # mappings that are initialized by __init__() at load time.
             for (p, p_info) in sort(products_info)
-                vp = variable_name(p)
-                println(io, """
-                # This will be filled out by __init__() for all products, as it must be done at runtime
-                $(vp)_path = ""
-
-                # $(vp)-specific global declaration
-                $(global_declaration(p, p_info))
-                """)
+                println(io, global_declaration(p, p_info))
             end
 
             print(io, """
-            \"\"\"
-            Open all libraries
-            \"\"\"
             function __init__()
-                # This either calls `@artifact_str()`, or returns a constant string if we're overridden.
-                global artifact_dir = find_artifact_dir()
-
-                global PATH_list, LIBPATH_list
+                JLLWrappers.@generate_init_header($(join(getname.(dependencies), ", ")))
             """)
-
-            if !isempty(dependencies)
-                # Note: this needs to be done at init time, because the path
-                # lists can change after precompile-time if we move the
-                # artifacts depot.
-                println(io, """
-                    # Initialize PATH and LIBPATH environment variable listings
-                    # From the list of our dependencies, generate a tuple of all the PATH and LIBPATH lists,
-                    # then append them to our own.
-                    foreach(p -> append!(PATH_list, p), ($(join(["$(getname(dep)).PATH_list" for dep in dependencies], ", ")),))
-                    foreach(p -> append!(LIBPATH_list, p), ($(join(["$(getname(dep)).LIBPATH_list" for dep in dependencies], ", ")),))
-                """)
-            end
 
             for (p, p_info) in sort(products_info)
                 vp = variable_name(p)
                 if p isa LibraryProduct || p isa FrameworkProduct
                     println(io, """
-                        global $(vp)_path, $(vp)_handle
-                        $(vp)_path, $(vp)_handle = get_lib_path_handle!(
-                            LIBPATH_list,
-                            artifact_dir,
+                        JLLWrappers.@init_library_product(
+                            $(vp),
                             $(repr(p_info["path"])),
-                            $(repr(dirname(p_info["path"]))),
                             $(BinaryBuilderBase.dlopen_flags_str(p)),
                         )
                     """)
                 elseif p isa ExecutableProduct
                     println(io, """
-                        global $(vp)_path = get_exe_path!(
-                            PATH_list,
-                            artifact_dir,
+                        JLLWrappers.@init_executable_product(
+                            $(vp),
                             $(repr(p_info["path"])),
-                            $(repr(dirname(p_info["path"]))),
                         )
                     """)
                 elseif p isa FileProduct
-                    println(io, "    global $(vp) = $(vp)_path")
+                    println(io, """
+                        JLLWrappers.@init_file_product(
+                            $(vp),
+                            $(repr(p_info["path"])),
+                        )
+                    """)
                 end
             end
 
-            # Final calculation of PATH/LIBPATH from PATH_list and LIBPATH_list
-            print(io, """
-                # Filter out duplicate and empty entries in our PATH and LIBPATH entries
-                global PATH, LIBPATH
-                PATH, LIBPATH = cleanup_path_libpath!(PATH_list, LIBPATH_list, $(repr(pathsep)))
-            """)
-
             if !isempty(init_block)
                 print(io, """
+                    JLLWrappers.@generate_init_footer()
 
                     $(init_block)
                 """)
@@ -1205,139 +1136,19 @@ function build_jll_package(src_name::String,
         end
     end
 
-    # Generate the script that dev's a JLL package out for local binary development work
-    open(joinpath(code_dir, "src", "dev.jl"), "w") do io
-        print(io, """
-        using Pkg, Pkg.Artifacts
-        # First, `dev` out the package, but don't effect the current project
-        mktempdir() do temp_env
-            Pkg.activate(temp_env) do
-                Pkg.develop("$(src_name)_jll")
-            end
-        end
-        # Create the override directory
-        override_dir = joinpath(Pkg.devdir(), "$(src_name)_jll", "override")
-        # Copy the current artifact contents into that directory
-        if !isdir(override_dir)
-            cp(artifact"$(src_name)", override_dir)
-        end
-        # Force recompilation of that package, just in case it wasn't dev'ed before
-        touch(joinpath(Pkg.devdir(), "$(src_name)_jll", "src", "$(src_name)_jll.jl"))
-        @info("$(src_name)_ll dev'ed out to $(joinpath(Pkg.devdir(), "$(src_name)_jll")) with pre-populated override directory")
-        """)
-    end
-
     # Generate target-demuxing main source file.
-    jll_jl = """
-        # Use baremodule to shave a few pieces of data off
+    open(joinpath(code_dir, "src", "$(src_name)_jll.jl"), "w") do io
+        print(io, """
+        # Use baremodule to shave off a few KB from the serialized `.ji` file
         baremodule $(src_name)_jll
         using Base
-        if VERSION < v"1.6.0-DEV"
-            # We lie a bit in the registry that JLL packages are usable on Julia 1.0-1.2.
-            # This is to allow packages that might want to support Julia 1.0 to get the
-            # benefits of a JLL package on 1.3 (requiring them to declare a dependence on
-            # this JLL package in their Project.toml) but engage in heroic hacks to do
-            # something other than actually use a JLL package on 1.0-1.2.  By allowing
-            # this package to be installed (but not loaded) on 1.0-1.2, we enable users
-            # to avoid splitting their package versions into pre-1.3 and post-1.3 branches
-            # if they are willing to engage in the kinds of hoop-jumping they might need
-            # to in order to install binaries in a JLL-compatible way on 1.0-1.2. One
-            # example of this hoop-jumping being to express a dependency on this JLL
-            # package, then import it within a `VERSION >= v"1.3"` conditional, and use
-            # the deprecated `build.jl` mechanism to download the binaries through e.g.
-            # `BinaryProvider.jl`.  This should work well for the simplest packages, and
-            # require greater and greater heroics for more and more complex packages.
-            error("Unable to import $(src_name)_jll on Julia versions older than 1.6!")
-        end
-
-        using Base.BinaryPlatforms, Artifacts, Libdl, JLLWrappers
         using Base: UUID
+        import JLLWrappers
 
-        if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
-            Core.eval($(src_name)_jll, :(Base.Experimental.@options compile=min optimize=0 infer=false))
-        end
-
-        \"\"\"
-            is_available()
-
-        Return whether the artifact is available for the current platform.
-        \"\"\"
-        function is_available end
-
-
-        # We put these inter-JLL-package API values here so that they are always defined, even if there
-        # is no underlying wrapper held within this JLL package.
-        const PATH_list = String[]
-        const LIBPATH_list = String[]
-
-        function find_artifact_dir()
-            # We determine at compile-time whether our JLL package has been dev'ed and overridden
-            @static if isdir(joinpath(dirname(@__DIR__), "override"))
-                return joinpath(dirname(@__DIR__), "override")
-            else
-                return artifact"$(src_name)"
-            end
-        end
-
-<<<<<<< HEAD
-            \"\"\"
-                dev_jll()
-
-            Check this package out to the dev package directory (usually ~/.julia/dev),
-            copying the artifact over to a local `override` directory, allowing package
-            developers to experiment with a locally-built binary.
-            \"\"\"
-            function dev_jll()
-                # We do this in an external process to avoid having to load `Pkg`.
-                run(`\$(Base.julia_cmd()) $(joinpath(@__DIR__, "dev.jl"))`)
-            end
-=======
-        \"\"\"
-            dev_jll()
-        
-        Check this package out to the dev package directory (usually ~/.julia/dev),
-        copying the artifact over to a local `override` directory, allowing package
-        developers to experiment with a locally-built binary.
-        \"\"\"
-        function dev_jll()
-            # We do this in an external process to avoid having to load `Pkg`.
-            run(`\$(Base.julia_cmd()) \$(joinpath(@__DIR__, "dev.jl"))`)
->>>>>>> Optimize for backedges
-        end
-        """
-    if Set(platforms) == Set([AnyPlatform()])
-        # We know directly the wrapper we want to include
-        jll_jl *= """
-            Base.include(@__MODULE__, joinpath(@__DIR__, "wrappers", "any.jl"))
-            """
-    else
-        jll_jl *= """
-            # Load Artifacts.toml file and choose best wrapper
-            best_wrapper = select_best_wrapper(
-                joinpath(@__DIR__, "..", "Artifacts.toml"),
-                $(repr(jll_uuid("$(src_name)_jll"))),
-                $(repr(src_name)),
-                @__DIR__,
-            )
-
-            # Silently fail if there's no binaries for this platform
-            if best_wrapper === nothing
-                @debug("Unable to load $(src_name); unsupported platform \$(triplet(platform_key_abi()))")
-                is_available() = false
-            else
-                Base.include($(src_name)_jll, best_wrapper)
-                is_available() = true
-            end
-            """
-    end
-    jll_jl *= """
-
+        JLLWrappers.@generate_main_file_header($(repr(src_name)))
+        JLLWrappers.@generate_main_file($(repr(src_name)), $(repr(jll_uuid("$(src_name)_jll"))))
         end  # module $(src_name)_jll
-        """
-
-
-    open(joinpath(code_dir, "src", "$(src_name)_jll.jl"), "w") do io
-        print(io, jll_jl)
+        """)
     end
 
     is_yggdrasil = get(ENV, "YGGDRASIL", "false") == "true"
@@ -1524,9 +1335,11 @@ function build_project_dict(name, version, dependencies::Array{Dependency}, juli
             project["compat"][depname] = string(exactly_this_version(dep.pkg.version))
         end
     end
-    # Always add Libdl and Pkg as dependencies
+    # Always add Libdl, Pkg and Artifacts as dependencies
+    # Once we stop supporting Julia 1.5-, we can drop the `Pkg` requirement.
     stdlibs = isdefined(Pkg.Types, :stdlib) ? Pkg.Types.stdlib : Pkg.Types.stdlibs
     project["deps"]["Libdl"] = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+    project["deps"]["Pkg"] = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
     project["deps"]["Artifacts"] = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
     project["deps"]["JLLWrappers"] = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -916,8 +916,8 @@ function rebuild_jll_package(obj::Dict;
     end
     if download_dir === nothing
         download_dir = mktempdir()
-        repo = "$(gh_org)/$(name)_jll.jl"
-        tag = "$(name)-v$(build_version)"
+        repo = "$(gh_org)/$(obj["name"])_jll.jl"
+        tag = "$(obj["name"])-v$(build_version)"
         download_github_release(download_dir, repo, tag; verbose=verbose)
         upload_prefix = "https://github.com/$(repo)/releases/download/$(tag)"
     elseif upload_prefix === nothing
@@ -998,19 +998,19 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
                 products_info,
             )
         end
-
-        # If `from_scratch` is set (the default) we clear out any old crusty code
-        # before generating our new, pristine, JLL package within it.  :)
-        if from_scratch
-            rm(joinpath(code_dir, "src"); recursive=true, force=true)
-            rm(joinpath(code_dir, "Artifacts.toml"); force=true)
-        end
-
-        # Finally, generate the full JLL package
-        build_jll_package(name, build_version, sources, code_dir, build_output_meta,
-                          dependencies, upload_prefix; verbose=verbose,
-                          kwargs...)
     end
+
+    # If `from_scratch` is set (the default) we clear out any old crusty code
+    # before generating our new, pristine, JLL package within it.  :)
+    if from_scratch
+        rm(joinpath(code_dir, "src"); recursive=true, force=true)
+        rm(joinpath(code_dir, "Artifacts.toml"); force=true)
+    end
+
+    # Finally, generate the full JLL package
+    build_jll_package(name, build_version, sources, code_dir, build_output_meta,
+                      dependencies, upload_prefix; verbose=verbose,
+                      kwargs...)
 end
 
 function build_jll_package(src_name::String,
@@ -1029,6 +1029,9 @@ function build_jll_package(src_name::String,
     end
     # Make way, for prince artifacti
     mkpath(joinpath(code_dir, "src", "wrappers"))
+
+    # Drop BuildDependency objects
+    dependencies = Dependency[d for d in dependencies if !isa(d, BuildDependency)]
 
     platforms = keys(build_output_meta)
     products_info = Dict{Product,Any}
@@ -1106,28 +1109,8 @@ function build_jll_package(src_name::String,
                 vp = variable_name(p)
                 # An executable product's public interface is a do-block wrapper function
                 return """
-                function $(vp)(f::Function; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
-                    global PATH, LIBPATH
-                    env_mapping = Dict{String,String}()
-                    if adjust_PATH
-                        if !isempty(get(ENV, "PATH", ""))
-                            env_mapping["PATH"] = string(PATH, $(repr(pathsep)), ENV["PATH"])
-                        else
-                            env_mapping["PATH"] = PATH
-                        end
-                    end
-                    if adjust_LIBPATH
-                        LIBPATH_base = get(ENV, LIBPATH_env, expanduser(LIBPATH_default))
-                        if !isempty(LIBPATH_base)
-                            env_mapping[LIBPATH_env] = string(LIBPATH, $(repr(pathsep)), LIBPATH_base)
-                        else
-                            env_mapping[LIBPATH_env] = LIBPATH
-                        end
-                    end
-                    withenv(env_mapping...) do
-                        f($(vp)_path)
-                    end
-                end
+                $(vp)(f::Function; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true) =
+                    executable_wrapper(f, $(vp)_path, PATH, LIBPATH, LIBPATH_env, LIBPATH_default, adjust_PATH, adjust_LIBPATH, ':')
                 """
             end
 
@@ -1145,6 +1128,7 @@ function build_jll_package(src_name::String,
                 println(io, """
                 # Relative path to `$(vp)`
                 const $(vp)_splitpath = $(repr(splitpath(p_info["path"])))
+                const $(vp)_joinpath = joinpath($(vp)_splitpath...)
 
                 # This will be filled out by __init__() for all products, as it must be done at runtime
                 $(vp)_path = ""
@@ -1167,6 +1151,18 @@ function build_jll_package(src_name::String,
 
                 global PATH_list, LIBPATH_list
             """)
+            if !isempty(dependencies)
+                print(io, """
+                # Initialize PATH and LIBPATH environment variable listings.
+                # From the list of our dependencies, generate a tuple of all the PATH and LIBPATH lists,
+                # then append them to our own.
+                foreach(p -> append!(PATH_list, p), ($(join(["$(getname(dep)).PATH_list" for dep in dependencies], ", ")),))
+                foreach(p -> append!(LIBPATH_list, p), ($(join(["$(getname(dep)).LIBPATH_list" for dep in dependencies], ", ")),))
+                """)
+            end
+            #println(io, "    initialize_path_list!(PATH_list, $(repr(tuple(["$(getname(dep)).PATH_list" for dep in dependencies]))))")
+            #println(io, "    initialize_path_list!(LIBPATH_list, $(repr(tuple(["$(getname(dep)).LIBPATH_list" for dep in dependencies]))))")
+
 
             if !isempty(dependencies)
                 # Note: this needs to be done at init time, because the path
@@ -1183,48 +1179,81 @@ function build_jll_package(src_name::String,
 
             for (p, p_info) in sort(products_info)
                 vp = variable_name(p)
-
-                # Initialize $(vp)_path
-                println(io, """
-                    global $(vp)_path = normpath(joinpath(artifact_dir, $(vp)_splitpath...))
-                """)
-
-                # If `p` is a `LibraryProduct`, dlopen() it right now!
                 if p isa LibraryProduct || p isa FrameworkProduct
                     println(io, """
-                        # Manually `dlopen()` this right now so that future invocations
-                        # of `ccall` with its `SONAME` will find this path immediately.
-                        global $(vp)_handle = dlopen($(vp)_path, $(BinaryBuilderBase.dlopen_flags_str(p)))
-                        push!(LIBPATH_list, dirname($(vp)_path))
+                        global $(vp)_path, $(vp)_handle
+                        $(vp)_path, $(vp)_handle = get_lib_path_handle!(LIBPATH_list, artifact_dir, $(vp)_joinpath, $(BinaryBuilderBase.dlopen_flags_str(p)))
                     """)
+                    # println(io, """
+                    #     global $(vp)_path = normpath(joinpath(artifact_dir, $(vp)_joinpath))
+                    #     global $(vp)_handle = dlopen($(vp)_path, $(BinaryBuilderBase.dlopen_flags_str(p)))
+                    #     push!(LIBPATH_list, dirname($(vp)_path))
+                    # """)
                 elseif p isa ExecutableProduct
-                    println(io, "    push!(PATH_list, dirname($(vp)_path))")
+                    println(io, """
+                        global $(vp)_path = get_exe_path!(PATH_list, artifact_dir, $(vp)_joinpath)
+                    """)
                 elseif p isa FileProduct
                     println(io, "    global $(vp) = $(vp)_path")
                 end
             end
+
+            # Final calculation of PATH/LIBPATH from PATH_list and LIBPATH_list
+            print(io, """
+                # Filter out duplicate and empty entries in our PATH and LIBPATH entries
+                global PATH, LIBPATH
+                PATH, LIBPATH = cleanup_path_libpath!(PATH_list, LIBPATH_list, $(repr(pathsep)))
+            """)
 
             # Libraries shipped by Julia can be found in different directories,
             # depending on the operating system and whether Julia has been built
             # from source or it's a pre-built binary. For all OSes libraries can
             # be found in Base.LIBDIR or Base.LIBDIR/julia, on Windows they are
             # in Sys.BINDIR, so we just add everything.
-            init_libpath = "joinpath(Sys.BINDIR, Base.LIBDIR, \"julia\"), joinpath(Sys.BINDIR, Base.LIBDIR)"
-            if isa(platform, Windows)
-                init_libpath = string("Sys.BINDIR, ", init_libpath)
+            # init_libpath = "JLLWrappers.get_julia_libpaths()"
+            # if isa(platform, Windows)
+            #     init_libpath = string("Sys.BINDIR, ", init_libpath)
+            # end
+            # print(io, """
+            #     # Filter out duplicate and empty entries in our PATH and LIBPATH entries
+            #     filter!(!isempty, unique!(PATH_list))
+            #     filter!(!isempty, unique!(LIBPATH_list))
+            #     global PATH = join(PATH_list, $(repr(pathsep)))
+            #     global LIBPATH = join(vcat(LIBPATH_list, $(init_libpath)), $(repr(pathsep)))
+            # """)
+            if !isempty(init_block)
+                print(io, """
+
+                    $(init_block)
+                """)
             end
 
-            print(io, """
-                # Filter out duplicate and empty entries in our PATH and LIBPATH entries
-                filter!(!isempty, unique!(PATH_list))
-                filter!(!isempty, unique!(LIBPATH_list))
-                global PATH = join(PATH_list, $(repr(pathsep)))
-                global LIBPATH = join(vcat(LIBPATH_list, [$(init_libpath)]), $(repr(pathsep)))
-
-                $(init_block)
+            print(io, """ 
             end  # __init__()
             """)
         end
+    end
+
+    # Generate the script that dev's a JLL package out for local binary development work
+    open(joinpath(code_dir, "src", "dev.jl"), "w") do io
+        print(io, """
+        using Pkg, Pkg.Artifacts
+        # First, `dev` out the package, but don't effect the current project
+        mktempdir() do temp_env
+            Pkg.activate(temp_env) do
+                Pkg.develop("$(src_name)_jll")
+            end
+        end
+        # Create the override directory
+        override_dir = joinpath(Pkg.devdir(), "$(src_name)_jll", "override")
+        # Copy the current artifact contents into that directory
+        if !isdir(override_dir)
+            cp(artifact"$(src_name)", override_dir)
+        end
+        # Force recompilation of that package, just in case it wasn't dev'ed before
+        touch(joinpath(Pkg.devdir(), "$(src_name)_jll", "src", "$(src_name)_jll.jl"))
+        @info("$(src_name)_ll dev'ed out to $(joinpath(Pkg.devdir(), "$(src_name)_jll")) with pre-populated override directory")
+        """)
     end
 
     # Generate target-demuxing main source file.
@@ -1235,7 +1264,7 @@ function build_jll_package(src_name::String,
             @eval Base.Experimental.@optlevel 0
         end
 
-        if VERSION < v"1.3.0-rc4"
+        if VERSION < v"1.6.0-DEV"
             # We lie a bit in the registry that JLL packages are usable on Julia 1.0-1.2.
             # This is to allow packages that might want to support Julia 1.0 to get the
             # benefits of a JLL package on 1.3 (requiring them to declare a dependence on
@@ -1250,10 +1279,10 @@ function build_jll_package(src_name::String,
             # the deprecated `build.jl` mechanism to download the binaries through e.g.
             # `BinaryProvider.jl`.  This should work well for the simplest packages, and
             # require greater and greater heroics for more and more complex packages.
-            error("Unable to import $(src_name)_jll on Julia versions older than 1.3!")
+            error("Unable to import $(src_name)_jll on Julia versions older than 1.6!")
         end
 
-        using Pkg, Pkg.BinaryPlatforms, Pkg.Artifacts, Libdl
+        using Base.BinaryPlatforms, Artifacts, Libdl, JLLWrappers
         import Base: UUID
 
         wrapper_available = false
@@ -1288,21 +1317,8 @@ function build_jll_package(src_name::String,
             developers to experiment with a locally-built binary.
             \"\"\"
             function dev_jll()
-                # First, `dev` out the package, but don't effect the current project
-                mktempdir() do temp_env
-                    Pkg.activate(temp_env) do
-                        Pkg.develop("$(src_name)_jll")
-                    end
-                end
-                # Create the override directory
-                override_dir = joinpath(Pkg.devdir(), "$(src_name)_jll", "override")
-                # Copy the current artifact contents into that directory
-                if !isdir(override_dir)
-                    cp(artifact"$(src_name)", override_dir)
-                end
-                # Force recompilation of that package, just in case it wasn't dev'ed before
-                touch(joinpath(Pkg.devdir(), "$(src_name)_jll", "src", "$(src_name)_jll.jl"))
-                @info("$(src_name)_ll dev'ed out to $(joinpath(Pkg.devdir(), "$(src_name)_jll")) with pre-populated override directory")
+                # We do this in an external process to avoid having to load `Pkg`.
+                run(`\$(Base.julia_cmd()) $(joinpath(@__DIR__, "dev.jl"))`)
             end
         end
         """
@@ -1317,14 +1333,14 @@ function build_jll_package(src_name::String,
             artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
 
             # Extract all platforms
-            artifacts = Pkg.Artifacts.load_artifacts_toml(artifacts_toml; pkg_uuid=$(repr(jll_uuid("$(src_name)_jll"))))
-            platforms = [Pkg.Artifacts.unpack_platform(e, $(repr(src_name)), artifacts_toml) for e in artifacts[$(repr(src_name))]]
+            artifacts = get_artifacts(artifacts_toml, $(repr(jll_uuid("$(src_name)_jll"))))
+            platforms = get_platforms($(repr(src_name)), artifacts_toml, artifacts)
 
             # Filter platforms based on what wrappers we've generated on-disk
-            filter!(p -> isfile(joinpath(@__DIR__, "wrappers", replace(triplet(p), "arm-" => "armv7l-") * ".jl")), platforms)
+            cleanup_platforms!(@__DIR__, platforms)
 
             # From the available options, choose the best platform
-            best_platform = select_platform(Dict(p => triplet(p) for p in platforms))
+            best_platform = select_best_platform(platforms)
 
             # Silently fail if there's no binaries for this platform
             if best_platform === nothing
@@ -1333,7 +1349,7 @@ function build_jll_package(src_name::String,
                 # Load the appropriate wrapper.  Note that on older Julia versions, we still
                 # say "arm-linux-gnueabihf" instead of the more correct "armv7l-linux-gnueabihf",
                 # so we manually correct for that here:
-                best_platform = replace(best_platform, "arm-" => "armv7l-")
+                best_platform = cleanup_best_platform(best_platform)
                 include(joinpath(@__DIR__, "wrappers", "\$(best_platform).jl"))
             end
             """
@@ -1534,8 +1550,9 @@ function build_project_dict(name, version, dependencies::Array{Dependency}, juli
     end
     # Always add Libdl and Pkg as dependencies
     stdlibs = isdefined(Pkg.Types, :stdlib) ? Pkg.Types.stdlib : Pkg.Types.stdlibs
-    project["deps"]["Libdl"] = first([string(u) for (u, n) in stdlibs() if n == "Libdl"])
-    project["deps"]["Pkg"] = first([string(u) for (u, n) in stdlibs() if n == "Pkg"])
+    project["deps"]["Libdl"] = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+    project["deps"]["Artifacts"] = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+    project["deps"]["JLLWrappers"] = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 
     return project
 end

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1135,9 +1135,6 @@ function build_jll_package(src_name::String,
             end
 
             print(io, """
-            # Inform that the wrapper is available for this platform
-            wrapper_available = true
-
             \"\"\"
             Open all libraries
             \"\"\"
@@ -1147,18 +1144,6 @@ function build_jll_package(src_name::String,
 
                 global PATH_list, LIBPATH_list
             """)
-            # if !isempty(dependencies)
-            #     print(io, """
-            #     # Initialize PATH and LIBPATH environment variable listings.
-            #     # From the list of our dependencies, generate a tuple of all the PATH and LIBPATH lists,
-            #     # then append them to our own.
-            #     foreach(p -> append!(PATH_list, p), ($(join(["$(getname(dep)).PATH_list" for dep in dependencies], ", ")),))
-            #     foreach(p -> append!(LIBPATH_list, p), ($(join(["$(getname(dep)).LIBPATH_list" for dep in dependencies], ", ")),))
-            #     """)
-            # end
-            #println(io, "    initialize_path_list!(PATH_list, $(repr(tuple(["$(getname(dep)).PATH_list" for dep in dependencies]))))")
-            #println(io, "    initialize_path_list!(LIBPATH_list, $(repr(tuple(["$(getname(dep)).LIBPATH_list" for dep in dependencies]))))")
-
 
             if !isempty(dependencies)
                 # Note: this needs to be done at init time, because the path
@@ -1186,11 +1171,6 @@ function build_jll_package(src_name::String,
                             $(BinaryBuilderBase.dlopen_flags_str(p)),
                         )
                     """)
-                    # println(io, """
-                    #     global $(vp)_path = normpath(joinpath(artifact_dir, $(vp)_joinpath))
-                    #     global $(vp)_handle = dlopen($(vp)_path, $(BinaryBuilderBase.dlopen_flags_str(p)))
-                    #     push!(LIBPATH_list, dirname($(vp)_path))
-                    # """)
                 elseif p isa ExecutableProduct
                     println(io, """
                         global $(vp)_path = get_exe_path!(
@@ -1212,22 +1192,6 @@ function build_jll_package(src_name::String,
                 PATH, LIBPATH = cleanup_path_libpath!(PATH_list, LIBPATH_list, $(repr(pathsep)))
             """)
 
-            # Libraries shipped by Julia can be found in different directories,
-            # depending on the operating system and whether Julia has been built
-            # from source or it's a pre-built binary. For all OSes libraries can
-            # be found in Base.LIBDIR or Base.LIBDIR/julia, on Windows they are
-            # in Sys.BINDIR, so we just add everything.
-            # init_libpath = "JLLWrappers.get_julia_libpaths()"
-            # if isa(platform, Windows)
-            #     init_libpath = string("Sys.BINDIR, ", init_libpath)
-            # end
-            # print(io, """
-            #     # Filter out duplicate and empty entries in our PATH and LIBPATH entries
-            #     filter!(!isempty, unique!(PATH_list))
-            #     filter!(!isempty, unique!(LIBPATH_list))
-            #     global PATH = join(PATH_list, $(repr(pathsep)))
-            #     global LIBPATH = join(vcat(LIBPATH_list, $(init_libpath)), $(repr(pathsep)))
-            # """)
             if !isempty(init_block)
                 print(io, """
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1254,7 +1254,7 @@ function build_jll_package(src_name::String,
         using Base: UUID
 
         if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
-            Core.eval($(src_name)_jll, :(Base.Experimental.@optlevel 0))
+            Core.eval($(src_name)_jll, :(Base.Experimental.@options compile=min optimize=0 infer=false))
         end
 
         \"\"\"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1130,7 +1130,7 @@ function build_jll_package(src_name::String,
                 """)
             end
 
-            print(io, """ 
+            print(io, """
             end  # __init__()
             """)
         end

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -9,10 +9,12 @@ module TestJLL end
     @test jll_uuid("FFMPEG_jll") == UUID("b22a6f82-2f65-5046-a5b2-351ab43fb4e5")
 
     project = build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), Dependency(PackageSpec(name = "XZ_jll", version = v"2.4.6"))])
-    @test project["deps"] == Dict("Pkg"      => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
-                                  "Zlib_jll" => "83775a58-1f1d-513f-b197-d71354ab007a",
-                                  "Libdl"    => "8f399da3-3557-5675-b5ff-fb832c97cbdb",
-                                  "XZ_jll"   => "ffd25f8a-64ca-5728-b0f7-c24cf3aae800")
+    @test project["deps"] == Dict("JLLWrappers" => "692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+                                  "Artifacts"   => "56f22d72-fd6d-98f1-02f0-08ddc0907c33",
+                                  "Pkg"         => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
+                                  "Zlib_jll"    => "83775a58-1f1d-513f-b197-d71354ab007a",
+                                  "Libdl"       => "8f399da3-3557-5675-b5ff-fb832c97cbdb",
+                                  "XZ_jll"      => "ffd25f8a-64ca-5728-b0f7-c24cf3aae800")
     @test project["name"] == "LibFoo_jll"
     @test project["uuid"] == "b250f842-3251-58d3-8ee4-9a24ab2bab3f"
     @test project["compat"] == Dict("julia" => "1.0", "XZ_jll" => "=2.4.6")


### PR DESCRIPTION
Changing JLL generation to use the new 1.6 `Artifacts` stdlib, instead of Pkg, and optimizing things to do more work at compile time.