### PR TITLE
Bump RootFS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ os:
   - linux
   # We don't have docker on OSX on travis at the moment... :(
   #- osx
-julia:
-  - 1.4
-  - 1.5
-  - nightly
 notifications:
   email: false
 git:
@@ -16,28 +12,34 @@ git:
 env:
   global:
     - BINARYBUILDER_AUTOMATIC_APPLE=true
-# cache:
-#   directories:
-#     - deps
 
 jobs:
   allow_failures:
     julia: nightly
   include:
     # Add a job that uses the privileged builder with squashfs shards
+    # Test this configuration on all Julia versions
     - julia: 1.4
+      env:
+        - BINARYBUILDER_RUNNER=privileged
+        - BINARYBUILDER_USE_SQUASHFS=true
+    - julia: 1.5
+      env:
+        - BINARYBUILDER_RUNNER=privileged
+        - BINARYBUILDER_USE_SQUASHFS=true
+    - julia: nightly
       env:
         - BINARYBUILDER_RUNNER=privileged
         - BINARYBUILDER_USE_SQUASHFS=true
 
     # Add a job that uses the unprivileged builder with unpacked shards
-    - julia: 1.4
+    - julia: 1.5
       env:
         - BINARYBUILDER_RUNNER=unprivileged
         - BINARYBUILDER_USE_SQUASHFS=false
 
     # Add a job that uses the docker builder with unpacked shards
-    - julia: 1.4
+    - julia: 1.5
       env:
         - BINARYBUILDER_RUNNER=docker
         - BINARYBUILDER_USE_SQUASHFS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ os:
   # We don't have docker on OSX on travis at the moment... :(
   #- osx
 julia:
-  - 1.3
   - 1.4
+  - 1.5
   - nightly
 notifications:
   email: false
@@ -25,19 +25,19 @@ jobs:
     julia: nightly
   include:
     # Add a job that uses the privileged builder with squashfs shards
-    - julia: 1.3
+    - julia: 1.4
       env:
         - BINARYBUILDER_RUNNER=privileged
         - BINARYBUILDER_USE_SQUASHFS=true
 
     # Add a job that uses the unprivileged builder with unpacked shards
-    - julia: 1.3.0
+    - julia: 1.4
       env:
         - BINARYBUILDER_RUNNER=unprivileged
         - BINARYBUILDER_USE_SQUASHFS=false
 
     # Add a job that uses the docker builder with unpacked shards
-    - julia: 1.3.0
+    - julia: 1.4
       env:
         - BINARYBUILDER_RUNNER=docker
         - BINARYBUILDER_USE_SQUASHFS=false

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -22,9 +22,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "UUIDs"]
-git-tree-sha1 = "3f5ba629988bfddd67b49b322c619da5d8e54c5c"
+git-tree-sha1 = "71d100f0db1cd5698139d2cf8d8fc7c828703379"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
-version = "0.3.0"
+version = "0.4.0"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -39,9 +39,9 @@ version = "1.3.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "edad9434967fdc0a2631a65d902228400642120c"
+git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.19"
+version = "0.17.20"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -58,30 +58,30 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FileIO]]
 deps = ["Pkg"]
-git-tree-sha1 = "202335fd24c2776493e198d6c66a6d910400a895"
+git-tree-sha1 = "1e7e88a949b52e6f7f589041bd60928322414997"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.3.0"
+version = "1.4.1"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[GitForge]]
 deps = ["Dates", "HTTP", "JSON2"]
-git-tree-sha1 = "4469573ba6e4c262ba3c3018de2166c063ec5c2d"
+git-tree-sha1 = "ded1b4ce9518e7568bad8dc20171a34684e8c6d2"
 uuid = "8f6bce27-0656-5410-875b-07a5572985df"
-version = "0.1.5"
+version = "0.1.6"
 
 [[GitHub]]
 deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets"]
-git-tree-sha1 = "a1c60c4079c54486e5e1daab1f4cdaebb21f6f63"
+git-tree-sha1 = "07e94aa019727a2d05b73b14f1e3b8f130c8dbc8"
 uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
-version = "5.1.6"
+version = "5.1.7"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "eca61b35cdd8cd2fcc5eec1eda766424a995b02f"
+git-tree-sha1 = "2ac03263ce44be4222342bca1c51c36ce7566161"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.16"
+version = "0.8.17"
 
 [[Hiccup]]
 deps = ["MacroTools", "Test"]
@@ -106,9 +106,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "FileIO", "Mmap", "Pkg", "Printf", "UUIDs"]
-git-tree-sha1 = "e03e697cf84c275ece9cbefd1eabaf49bf5e7254"
+git-tree-sha1 = "9353b717ee4e27beab4e902c92a06bb5f160d2cf"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.1.13"
+version = "0.1.14"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -124,9 +124,9 @@ version = "0.3.2"
 
 [[Lazy]]
 deps = ["MacroTools"]
-git-tree-sha1 = "0bd934e15f5df97414aa81abf74ba8a2d5042964"
+git-tree-sha1 = "1370f8202dac30758f3c345f9909b97f53d87d3f"
 uuid = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
-version = "0.15.0"
+version = "0.15.1"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -143,9 +143,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[LoggingExtras]]
-git-tree-sha1 = "b60616c70eff0cc2c0831b6aace75940aeb0939d"
+deps = ["Dates"]
+git-tree-sha1 = "03289aba73c0abc25ff0229bed60f2a4129cd15c"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-version = "0.4.1"
+version = "0.4.2"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
@@ -174,9 +175,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Mustache]]
 deps = ["Printf", "Tables"]
-git-tree-sha1 = "fcfc8266461f2905534aa00c0fc59b8751b1026e"
+git-tree-sha1 = "3d07128636eddde25a17aced63dbcedbce71a79d"
 uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-version = "1.0.3"
+version = "1.0.4"
 
 [[Mux]]
 deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "Test", "WebSockets"]
@@ -186,9 +187,9 @@ version = "0.7.0"
 
 [[ObjectFile]]
 deps = ["Reexport", "StructIO", "Test"]
-git-tree-sha1 = "26bf52f95a07d471a4ec2dcae6774584e7d2d7c1"
+git-tree-sha1 = "c1b7b18d497eda21411c2e2075395edb10a42ee3"
 uuid = "d8793406-e978-5875-9003-1fc021f44a92"
-version = "0.3.4"
+version = "0.3.5"
 
 [[OrderedCollections]]
 git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
@@ -202,9 +203,9 @@ version = "0.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "10134f2ee0b1978ae7752c41306e131a684e1f06"
+git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.7"
+version = "1.0.10"
 
 [[Pidfile]]
 deps = ["FileWatching", "Test"]
@@ -228,9 +229,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[ProgressMeter]]
 deps = ["Distributed", "Printf"]
-git-tree-sha1 = "3e1784c27847bba115815d4d4e668b99873985e5"
+git-tree-sha1 = "2de4cddc0ceeddafb6b143b5b6cd9c659b64507c"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.3.1"
+version = "1.3.2"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
@@ -248,9 +249,9 @@ version = "0.2.0"
 
 [[Registrator]]
 deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mustache", "Mux", "Pkg", "RegistryTools", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
-git-tree-sha1 = "fc03fdec0e29ab36e3e994a08cb8272f53f65354"
+git-tree-sha1 = "7c16227cd1dc9bae38e25d6dc6f9c020f8ebca46"
 uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
-version = "1.2.0"
+version = "1.2.1"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
@@ -281,9 +282,9 @@ version = "1.0.0"
 
 [[Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "c45dcc27331febabc20d86cb3974ef095257dcf3"
+git-tree-sha1 = "b7f762e9820b7fab47544c36f26f54ac59cf8abf"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.0.4"
+version = "1.0.5"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
@@ -333,9 +334,9 @@ version = "4.3.2+4"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "622d8b6dc0c7e8029f17127703de9819134d1b71"
+git-tree-sha1 = "d5bba6485811931e4b8958e2d7ca3738273ac468"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+14"
+version = "1.2.11+15"
 
 [[ghr_jll]]
 deps = ["Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilder"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
@@ -32,7 +32,7 @@ ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
 ArgParse = "1.1"
-BinaryBuilderBase = "0.3"
+BinaryBuilderBase = "0.4"
 GitHub = "5.1"
 HTTP = "0.8"
 JLD2 = "0.1.6"
@@ -45,7 +45,7 @@ ProgressMeter = "1"
 Registrator = "1.1"
 RegistryTools = "1.3.4"
 ghr_jll = "0.13.0"
-julia = "1.3"
+julia = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -382,7 +382,7 @@ function get_next_wrapper_version(src_name, src_version)
     ctx = Pkg.Types.Context()
 
     # Force-update the registry here, since we may have pushed a new version recently
-    update_registry(ctx)
+    update_registry(ctx, devnull)
 
     # If it does, we need to bump the build number up to the next value
     build_number = 0
@@ -597,7 +597,7 @@ function autobuild(dir::AbstractString,
     build_output_meta = Dict()
 
     # Resolve dependencies into PackageSpecs now, ensuring we have UUIDs for all deps
-    all_resolved, dependencies = resolve_jlls(dependencies)
+    all_resolved, dependencies = resolve_jlls(dependencies, outs=(verbose ? stdout : devnull))
     if !all_resolved
         error("Invalid dependency specifications!")
     end
@@ -627,7 +627,7 @@ function autobuild(dir::AbstractString,
             source_files;
             verbose=verbose,
         )
-        artifact_paths = setup_dependencies(prefix, getpkg.(dependencies), concrete_platform)
+        artifact_paths = setup_dependencies(prefix, getpkg.(dependencies), concrete_platform; verbose=verbose)
 
         # Create a runner to work inside this workspace with the nonce built-in
         ur = preferred_runner()(

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1183,7 +1183,7 @@ function build_jll_package(src_name::String,
                     println(io, """
                         # Manually `dlopen()` this right now so that future invocations
                         # of `ccall` with its `SONAME` will find this path immediately.
-                        global $(vp)_handle = dlopen($(vp)_path$(BinaryBuilderBase.dlopen_flags_str(p)))
+                        global $(vp)_handle = dlopen($(vp)_path, $(BinaryBuilderBase.dlopen_flags_str(p)))
                         push!(LIBPATH_list, dirname($(vp)_path))
                     """)
                 elseif p isa ExecutableProduct

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -243,6 +243,7 @@ function is_default_lib(lib, ::ELFHandle)
         "libgfortran.so.3",
         "libgfortran.so.4",
         "libgfortran.so.5",
+        "libquadmath.so.0",
         "libgomp.so.1",
         "libstdc++.so.6",
         "libc++.so.1",

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -257,7 +257,7 @@ function valid_library_path(f::AbstractString, p::Platform)
     elseif Sys.isapple(p)
         return endswith(f, ".dylib")
     else
-        return occursin(r".*.so(\.[\d]+)*", f)
+        return occursin(r".+\.so(\.[\d]+)*", f)
     end
 end
 

--- a/src/wizard/interactive_build.jl
+++ b/src/wizard/interactive_build.jl
@@ -518,7 +518,7 @@ function step34(state::WizardState)
                                               preferred_gcc_version = state.preferred_gcc_version,
                                               preferred_llvm_version = state.preferred_llvm_version,
                                               compilers = state.compilers)
-    artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), concrete_platform)
+    artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), concrete_platform; verbose=true)
 
     provide_hints(state, joinpath(prefix, "srcdir"))
 
@@ -566,7 +566,7 @@ function step5_internal(state::WizardState, platform::Platform)
                                                       preferred_gcc_version = state.preferred_gcc_version,
                                                       preferred_llvm_version = state.preferred_llvm_version,
                                                       compilers = state.compilers)
-            artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), concrete_platform)
+            artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), concrete_platform; verbose=true)
             # Record newly added artifacts for this prefix
             prefix_artifacts[prefix] = artifact_paths
             ur = preferred_runner()(
@@ -644,7 +644,7 @@ function step5_internal(state::WizardState, platform::Platform)
                                                                   preferred_gcc_version = state.preferred_gcc_version,
                                                                   preferred_llvm_version = state.preferred_llvm_version,
                                                                   compilers = state.compilers)
-                        artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), platform)
+                        artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), platform; verbose=true)
                         # Record newly added artifacts for this prefix
                         prefix_artifacts[prefix] = artifact_paths
 
@@ -779,7 +779,7 @@ function step5c(state::WizardState)
                                                   preferred_gcc_version = state.preferred_gcc_version,
                                                   preferred_llvm_version = state.preferred_llvm_version,
                                                   compilers = state.compilers)
-        artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), concrete_platform)
+        artifact_paths = setup_dependencies(prefix, getpkg.(state.dependencies), concrete_platform; verbose=false)
         ur = preferred_runner()(
             prefix.path;
             cwd="/workspace/srcdir",

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -53,22 +53,37 @@ end
 
 @testset "environment and history saving" begin
     mktempdir() do temp_path
-        @test_throws ErrorException autobuild(
+        # This is a litmus test, to catch any errors before we do a `@test_throws`
+        autobuild(
             temp_path,
-            "this_will_fail",
+            "this_will_pass",
             v"1.0.0",
             # No sources to speak of
             FileSource[],
-            # Simple script that just sets an environment variable
+            # Just exit with code 0
             """
-            MARKER=1
-            exit 1
+            exit 0
             """,
             # Build for this platform
             [platform],
             # No products
             Product[],
             # No depenedencies
+            Dependency[],
+        )
+
+        @test_throws ErrorException autobuild(
+            temp_path,
+            "this_will_fail",
+            v"1.0.0",
+            FileSource[],
+            # Simple script that just sets an environment variable
+            """
+            MARKER=1
+            exit 1
+            """,
+            [platform],
+            Product[],
             Dependency[],
         )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ install_license ${WORKSPACE}/srcdir/libfoo/LICENSE.md
 libfoo_meson_script = raw"""
 mkdir ${WORKSPACE}/srcdir/libfoo/build && cd ${WORKSPACE}/srcdir/libfoo/build
 meson .. -Dprefix=${prefix} --cross-file="${MESON_TARGET_TOOLCHAIN}"
-ninja install -v
+meson install
 
 # grumble grumble meson!  Why do you go to all the trouble to build it properly
 # in `build`, then screw it up when you `install` it?!  Silly willy.


### PR DESCRIPTION
This PR also fixes a whole bunch of testing issues.

This version includes the new RootFS and PlatformSupport shards, which bundles new versions of musl, glibc, the macos SDK, and includes a RootFS that is based on Alpine 3.12.

Closes #893