### PR TITLE
Do not write UUID of packages without UUID in wizard script

### DIFF
--- a/src/Wizard.jl
+++ b/src/Wizard.jl
@@ -17,7 +17,7 @@ using Pkg.BinaryPlatforms
 using Dates
 
 # It's Magic (TM)!
-export run_wizard
+export run_wizard, deploy
 
 include("wizard/state.jl")
 include("wizard/github.jl")

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -55,7 +55,14 @@ function print_build_tarballs(io::IO, state::WizardState)
     end
 
     if length(state.dependencies) >= 1
-        psrepr(ps) = "\n    Dependency(PackageSpec(name=\"$(getname(ps))\", uuid=\"$(getpkg(ps).uuid)\"))"
+        function psrepr(ps)
+            s = "\n    Dependency(PackageSpec(name=\"$(getname(ps))\""
+            if !isnothing(getpkg(ps).uuid)
+                s *= ", uuid=\"$(getpkg(ps).uuid)\""
+            end
+            s *= "))"
+            return s
+        end
         dependencies_string = "[" * join(map(psrepr, state.dependencies)) * "\n]"
     else
         dependencies_string = "Dependency[\n]"


### PR DESCRIPTION
We can make the `bb add` smarter and get also the UUID of the package, but I
think this check is good regardless of that improvement.

Ref #818.