### PR TITLE
Fix permissions before cleaning-up directory during rebuild of JLLs

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1009,6 +1009,9 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
                 git_hash,
                 products_info,
             )
+
+            # Override read-only permissions before cleaning-up the directory
+            chmod(dest_prefix, filemode(dest_prefix) | 0o200; recursive=true)
         end
     end
 


### PR DESCRIPTION
Some packages, like `ICU_jll`, have files with pesky permissions which prevent
cleaning-up the temporary directory.