### PR TITLE
Teach audit to check multiple CSL libraries

### DIFF
--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -90,8 +90,9 @@ function audit(prefix::Prefix, src_name::AbstractString = "";
                     if isdynamic(oh)
                         # Check that the libgfortran version matches
                         all_ok &= check_libgfortran_version(oh, platform; verbose=verbose, has_csl = has_csl)
-                        # Check whether the library depends on libgomp
-                        all_ok &= check_libgomp(oh, platform; verbose=verbose, has_csl = has_csl)
+                        # Check whether the library depends on any of the most common
+                        # libraries provided by `CompilerSupportLibraries_jll`.
+                        all_ok &= check_csl_libs(oh, platform; verbose=verbose, has_csl=has_csl)
                         # Check that the libstdcxx string ABI matches
                         all_ok &= check_cxxstring_abi(oh, platform; verbose=verbose)
                         # Check that this binary file's dynamic linkage works properly.  Note to always

--- a/src/auditor/compiler_abi.jl
+++ b/src/auditor/compiler_abi.jl
@@ -66,7 +66,7 @@ end
 function check_csl_libs(oh::ObjectHandle, platform::AbstractPlatform; verbose::Bool=false,
                         has_csl::Bool=true, csl_libs::Vector{String}=["libgomp", "libatomic"])
     if has_csl
-        # No need to do any check, CompilerSupportLibraries_jll si already a dependency
+        # No need to do any check, CompilerSupportLibraries_jll is already a dependency
         return true
     end
 


### PR DESCRIPTION
In addition to `libgomp`, it's possible that a library links against libatomic,
so we need to check also that one.