### PR TITLE
compat bounds: fix version range test for 'x.y.0-x.y'

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1354,6 +1354,7 @@ function build_project_dict(name, version, dependencies::Array{Dependency}, juli
     end
     function exactly_this_version(v::Pkg.Types.VersionSpec)
         if length(v.ranges) == 1 &&
+           v.ranges[1].lower.n == 3 &&
            v.ranges[1].lower == v.ranges[1].upper
            return string("=", v)
        end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -233,4 +233,10 @@ end
     dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
     @test dict["compat"]["julia"] == "1.0"
     @test dict["compat"]["libLLVM_jll"] == "8.3-10"
+
+    dependencies = [
+        Dependency(PackageSpec(name="libLLVM_jll", version="8.3.0-8.3")),
+    ]
+    dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
+    @test dict["compat"]["libLLVM_jll"] == "8.3"
 end


### PR DESCRIPTION
Without this change we have the following behaviour (using the `exactly_this_version` function from `AutoBuild.jl`):
```julia
julia> exactly_this_version(VersionSpec("8.3"))
"=8.3"
julia> exactly_this_version(VersionSpec("8.3.0-8.3"))
"=8.3"
julia> exactly_this_version(VersionSpec("8.3.1-8.3"))
"8.3.1-8.3"
```
Similarly `8.0-8` or `8` returns `=8` instead if just `8`.
In these cases the lower bound equals the upper bound but not all three version components are fixed.

I tried looking into Pkg.jl (`src/versions.jl`) but could not think of any way to do this without accessing that field directly.