### PR TITLE
Using MMX, SSE, SSE2 requires prescott

### DIFF
--- a/src/auditor/instruction_set.jl
+++ b/src/auditor/instruction_set.jl
@@ -103,7 +103,10 @@ function minimum_march(counts::Dict, p::AbstractPlatform)
             return "avx"
         end
     elseif arch(p) == "i686"
-        if counts["sse3"] > 0
+        prescott_instruction_categories = (
+            "mmx", "sse", "sse2", "sse3",
+        )
+        if any(get.(Ref(counts), prescott_instruction_categories, 0) .> 0)
             return "prescott"
         end
     elseif arch(p) == "aarch64"


### PR DESCRIPTION
If we detect that a 32bit x86 binary is using MMX, SSE, SSE2, then -march=i686 is not sufficient, so suggest -march=prescott instead.

... well, at least based on how I understand things. Perhaps I got this completely backwards, though, I am extrapolating from very localized knowledge of the codebase, I certainly don't understand the "big picture" fully.

There are certainly alternatives to this PR: e.g. one could teach BB more 32bit architectures and refine this. Or one could decide that since Julia itself requires SSE2 for its atomics support, the base architecture shouldn't be `i686` (i.e., Pentium Pro), but rather `pentium4`.

This came to my attention in the context of `libjulia_jll`, see [the discussion starting at this comment](https://github.com/JuliaPackaging/Yggdrasil/pull/1948#discussion_r511532755).