### PR TITLE
[AutoBuild] Increase compat of JLLWrappers to v1.2.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -123,9 +123,9 @@ uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 version = "0.1.14"
 
 [[JLLWrappers]]
-git-tree-sha1 = "04b49c556240b62d5a799e94c63d5fc14d3c07cd"
+git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.1.4"
+version = "1.2.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
       set -e
       $(JULIA) -e 'using Pkg; Pkg.instantiate()'
       $(JULIA) -e 'using BinaryBuilder; BinaryBuilder.versioninfo()'
-      $(JULIA) -e 'using Pkg; Pkg.status()'
+      $(JULIA) -e 'using Pkg; Pkg.status(; mode=PKGMODE_MANIFEST)'
     name: SystemInfo
 
 - job: Test
@@ -47,7 +47,7 @@ jobs:
   steps:
   - bash: |
       set -e
-      $(JULIA) --check-bounds=yes --inline=yes -e 'using Pkg; Pkg.Registry.update(); Pkg.test(coverage=true)'
+      $(JULIA) --check-bounds=yes --inline=yes -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.test(coverage=true)'
       $(JULIA) -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
     name: Test
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1372,7 +1372,7 @@ function build_project_dict(name, version, dependencies::Array{Dependency}, juli
         "deps" => Dict{String,Any}(),
         # We require at least Julia 1.3+, for Pkg.Artifacts support, but we only claim
         # Julia 1.0+ by default so that empty JLLs can be installed on older versions.
-        "compat" => Dict{String,Any}("JLLWrappers" => "1.1.0",
+        "compat" => Dict{String,Any}("JLLWrappers" => "1.2.0",
                                      "julia" => "$(julia_compat)")
     )
     for dep in dependencies

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -187,7 +187,7 @@ end
     @test dict["name"] == "$(name)_jll"
     @test dict["version"] == "1.0.0"
     @test dict["uuid"] == "8fcd9439-76b0-55f4-a525-bad0597c05d8"
-    @test dict["compat"] == Dict{String,Any}("julia" => "1.0", "JLLWrappers" => "1.1.0")
+    @test dict["compat"] == Dict{String,Any}("julia" => "1.0", "JLLWrappers" => "1.2.0")
     @test all(in.(
         (
             "Pkg"       => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
@@ -212,10 +212,10 @@ end
 
     # Ensure passing a Julia dependency bound works
     dict = build_project_dict(name, version, dependencies, "1.4")
-    @test dict["compat"] == Dict{String,Any}("julia" => "1.4", "JLLWrappers" => "1.1.0")
+    @test dict["compat"] == Dict{String,Any}("julia" => "1.4", "JLLWrappers" => "1.2.0")
 
     dict = build_project_dict(name, version, dependencies, "~1.4")
-    @test dict["compat"] == Dict{String,Any}("julia" => "~1.4", "JLLWrappers" => "1.1.0")
+    @test dict["compat"] == Dict{String,Any}("julia" => "~1.4", "JLLWrappers" => "1.2.0")
 
     @test_throws ErrorException build_project_dict(name, version, dependencies, "nonsense")
 

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -17,7 +17,7 @@ module TestJLL end
                                   "XZ_jll"      => "ffd25f8a-64ca-5728-b0f7-c24cf3aae800")
     @test project["name"] == "LibFoo_jll"
     @test project["uuid"] == "b250f842-3251-58d3-8ee4-9a24ab2bab3f"
-    @test project["compat"] == Dict("julia" => "1.0", "XZ_jll" => "=2.4.6", "JLLWrappers" => "1.1.0")
+    @test project["compat"] == Dict("julia" => "1.0", "XZ_jll" => "=2.4.6", "JLLWrappers" => "1.2.0")
     @test project["version"] == "1.3.5"
     # Make sure BuildDependency's don't find their way to the project
     @test_throws MethodError build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), BuildDependency("Xorg_util_macros_jll")])


### PR DESCRIPTION
Because of https://github.com/JuliaPackaging/JLLWrappers.jl/pull/24 and
https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/90, we need to bump
the compat version of `JLLWrappers.jl`.