### PR TITLE
[Auditor] Improve check for amv7l float ABI

### DIFF
--- a/src/auditor/extra_checks.jl
+++ b/src/auditor/extra_checks.jl
@@ -18,8 +18,9 @@ function check_os_abi(oh::ObjectHandle, p::AbstractPlatform, rest...; verbose::B
     elseif call_abi(p) == "eabihf"
         # Make sure the object file has the hard-float ABI.  See Table 4-2 of
         # "ELF for the ARM Architecture" document
-        # (https://developer.arm.com/documentation/ihi0044/e/).
-        if iszero(header(oh).e_flags & 0x400)
+        # (https://developer.arm.com/documentation/ihi0044/e/).  Note: `0x000`
+        # means "no specific float ABI", `0x400` == EF_ARM_ABI_FLOAT_HARD.
+        if header(oh).e_flags & 0xF00 ∉ (0x000, 0x400)
             if verbose
                 @error("$(basename(path(oh))) does not match the hard-float ABI")
             end

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -564,8 +564,9 @@ end
 end
 
 @testset "Auditor - other checks" begin
+    platform = Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc")
     mktempdir() do build_path
-        @test_logs (:error, r"does not match the hard-float ABI") match_mode=:any begin
+        build_output_meta = @test_logs (:error, r"libsoft.so does not match the hard-float ABI") match_mode=:any begin
             autobuild(
                 build_path,
                 "hard_float_ABI",
@@ -575,19 +576,45 @@ end
                 # Build a library which doesn't link to the standard library and
                 # forces the soft-float ABI
                 raw"""
-                mkdir -p "${libdir}"
-                echo 'int _start() { return 0; }' | /opt/${target}/bin/${target}-gcc -nostdlib -shared -mfloat-abi=soft -o "${libdir}/libfoo.${dlext}" -x c -
+                mkdir -p "${libdir}" "${bindir}"
+                # This library has hard-float ABI
+                echo 'int test() { return 0; }' | cc -shared -fPIC -o "${libdir}/libhard.${dlext}" -x c -
+                # This library has soft-float ABI
+                echo 'int _start() { return 0; }' | /opt/${target}/bin/${target}-gcc -nostdlib -shared -mfloat-abi=soft -o "${libdir}/libsoft.${dlext}" -x c -
+                # hello_world built by Go doesn't specify any float ABI
+                make -C /usr/share/testsuite/go/hello_world/
+                cp "/tmp/testsuite/${target}/go/hello_world/hello_world" "${bindir}/hello_world"
                 """,
                 # Build for Linux armv7l hard-float
-                [Platform("armv7l", "linux"; call_abi = "eabihf", libc = "glibc")],
+                [platform],
                 # Ensure our library product is built
-                [LibraryProduct("libfoo", :libfoo)],
+                [
+                    LibraryProduct("libhard", :libhard),
+                    LibraryProduct("libsoft", :libsoft),
+                    ExecutableProduct("hello_world", :hello_world),
+                ],
                 # No dependencies
                 Dependency[];
+                compilers = [:c, :go],
                 verbose = true,
                 require_license = false
             )
         end
+
+        @test haskey(build_output_meta, platform)
+        tarball_path, tarball_hash = build_output_meta[platform][1:2]
+        @test isfile(tarball_path)
+
+        # Unpack it somewhere else
+        @test verify(tarball_path, tarball_hash)
+        testdir = joinpath(build_path, "testdir")
+        mkdir(testdir)
+        unpack(tarball_path, testdir)
+        # Remove libsoft.so, we want to run audit only on the other products
+        rm(joinpath(testdir, "lib", "libsoft.so"))
+        # Make sure `hello_world` passes the float ABI check even if it doesn't
+        # set `EF_ARM_ABI_FLOAT_HARD`.
+        @test Auditor.audit(Prefix(testdir); platform=platform, require_license=false)
     end
 end
 


### PR DESCRIPTION
A binary is accpetable for this platform also if it doesn't specify any float
ABI.

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/2455.