### PR TITLE
WIP: Use package function from BinaryBuilderBase

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1,4 +1,6 @@
 export build_tarballs, autobuild, print_artifacts_toml, build, get_meta_json
+
+using BinaryBuilderBase: _package_fast
 import GitHub: gh_get_json, DEFAULT_API
 import SHA: sha256, sha1
 using Pkg.TOML, Dates, UUIDs
@@ -815,7 +817,7 @@ function autobuild(dir::AbstractString,
         compress_dir(joinpath(dest_prefix.path, "logs"), verbose=verbose)
 
         # Once we're built up, go ahead and package this dest_prefix out
-        tarball_path, tarball_hash, git_hash = package(
+        tarball_path, tarball_hash, git_hash = _package_fast(
             dest_prefix,
             joinpath(out_path, src_name),
             src_version;


### PR DESCRIPTION
Allows BinaryBuilder to use the faster package compression introduced in BinaryBuilderBase in https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/107. I didn't expect BB would call Pkg's `package` function directly so ideally I'll update BinaryBuilderBase with an function not marked as internal. To start with I figured I'd open this PR for feedback.