### PR TITLE
Add space before github tokens URL

### DIFF
--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -93,12 +93,12 @@ function obtain_token(; outs=stdout, github_api=GitHub.DEFAULT_API)
 
         token = token_reply["access_token"]
 
-        print(outs, strip("""
+        print(outs, """
         Successfully obtained GitHub authorization token!
         This token will be used for the rest of this BB session.
         You will have to re-authenticate for any future session.
         However, if you wish to bypass this step, you may create a
-        personal access token at """))
+        personal access token at """)
         printstyled("https://github.com/settings/tokens"; bold=true)
         println("\n and add the token to the")
         printstyled(outs, "~/.julia/config/startup.jl"; bold=true)


### PR DESCRIPTION
Example of the original output:
```
Authenticating with GitHub
To continue, we need to authenticate you with GitHub. Please navigate to
the following page in your browser and enter the code below:

     https://github.com/login/device

     #############
     # XXXX-XXXX #
     #############

Successfully obtained GitHub authorization token!
This token will be used for the rest of this BB session.
You will have to re-authenticate for any future session.
However, if you wish to bypass this step, you may create a
personal access token athttps://github.com/settings/tokens
 and add the token to the
~/.julia/config/startup.jl file as:

    ENV["GITHUB_TOKEN"] = <token>
This token is sensitive, so only do this in a computing environment you trust.
```