### PR TITLE
Produce compat entries in Project.toml

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,7 +28,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "87236ea2e2cf83b4a5bbeb29bc76c94f4a3252d4"
+git-tree-sha1 = "c3ceefb6a48993dd35514fac7f00f8e7b7addb2b"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -221,21 +221,21 @@ end
 
     # Ensure passing compat bounds works
     dependencies = [
-        Dependency(PackageSpec(name="libLLVM_jll", version=v"9")),
+        Dependency(PackageSpec(name="libLLVM_jll"), compat="=9.0.0"),
     ]
     dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
     @test dict["compat"]["julia"] == "1.0"
     @test dict["compat"]["libLLVM_jll"] == "=9.0.0"
 
     dependencies = [
-        Dependency(PackageSpec(name="libLLVM_jll", version="8.3-10")),
+        Dependency(PackageSpec(name="libLLVM_jll"), compat="8.3 - 10"),
     ]
     dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
     @test dict["compat"]["julia"] == "1.0"
-    @test dict["compat"]["libLLVM_jll"] == "8.3-10"
+    @test dict["compat"]["libLLVM_jll"] == "8.3 - 10"
 
     dependencies = [
-        Dependency(PackageSpec(name="libLLVM_jll", version="8.3.0-8.3")),
+        Dependency(PackageSpec(name="libLLVM_jll"), compat="8.3"),
     ]
     dict = build_project_dict("Clang", v"9.0.1+2", dependencies)
     @test dict["compat"]["libLLVM_jll"] == "8.3"

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -8,7 +8,7 @@ module TestJLL end
     @test jll_uuid("Zlib_jll") == UUID("83775a58-1f1d-513f-b197-d71354ab007a")
     @test jll_uuid("FFMPEG_jll") == UUID("b22a6f82-2f65-5046-a5b2-351ab43fb4e5")
 
-    project = build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), Dependency(PackageSpec(name = "XZ_jll", version = v"2.4.6"))])
+    project = build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), Dependency(PackageSpec(name = "XZ_jll"), compat = "=2.4.6")])
     @test project["deps"] == Dict("JLLWrappers" => "692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
                                   "Artifacts"   => "56f22d72-fd6d-98f1-02f0-08ddc0907c33",
                                   "Pkg"         => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",


### PR DESCRIPTION
... using the optional meta data provided by users in BBB's Dependency type.

This is companion to PR https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/123, and part of a new effort to address https://github.com/JuliaPackaging/BinaryBuilderBase.jl/issues/89. My previous attempt, https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/98, was not sufficient, as it failed to address the core issue: that while a compat string can be turned into a VersionSpec, the reverse is in general not possible; so specifying the compat bounds using a VersionSpec isn't too useful. The solution chosen here is to instead simply store it as a string (validated by calling `semver_spec` on it).

Unfortunately, this change is completely untested! The reason is that I am not sure at this point how I would adequately test it. Perhaps I can figure that out tomorrow, but I wanted to already open the PRs now to give people a chance to look at them.
