### PR TITLE
Use `Tar.jl` to create tarball to use for Wizard tests

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,7 +28,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryBuilderBase]]
 deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
-git-tree-sha1 = "557b497af843c3f48fe4678c4b47b13db81805aa"
+git-tree-sha1 = "87236ea2e2cf83b4a5bbeb29bc76c94f4a3252d4"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaPackaging/BinaryBuilderBase.jl.git"
 uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
@@ -122,9 +122,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["CodecZlib", "DataStructures", "MacroTools", "Mmap", "Pkg", "Printf", "Requires", "UUIDs"]
-git-tree-sha1 = "e8c4d588007dc02a1b23442ef3d14a8d7146df97"
+git-tree-sha1 = "b8343a7f96591404ade118b3a7014e1a52062465"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.1"
+version = "0.4.2"
 
 [[JLLWrappers]]
 git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
@@ -234,9 +234,9 @@ version = "0.1.0"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+git-tree-sha1 = "223a825cccef2228f3fdbf2ecc7ca93363059073"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.15"
+version = "1.0.16"
 
 [[Pidfile]]
 deps = ["FileWatching", "Test"]
@@ -245,7 +245,7 @@ uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
 version = "1.2.0"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PkgLicenses]]

--- a/Project.toml
+++ b/Project.toml
@@ -52,8 +52,9 @@ julia = "1.6"
 
 [extras]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VT100 = "7774df62-37c0-5c21-b34d-f6d7f98f54bc"
 
 [targets]
-test = ["JLLWrappers", "Test", "VT100"]
+test = ["JLLWrappers", "Tar", "Test", "VT100"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ variables:
   JULIA: unbuffer julia --project=$(Build.SourcesDirectory) --color=yes
   BINARYBUILDER_AUTOMATIC_APPLE: true
   BINARYBUILDER_USE_CCACHE: true
+  CI: true
 
 jobs:
 - job: Info

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -1,5 +1,5 @@
 using BinaryBuilder, BinaryBuilder.BinaryBuilderBase, BinaryBuilder.Wizard
-using GitHub, Test, VT100, Sockets, HTTP, SHA
+using GitHub, Test, VT100, Sockets, HTTP, SHA, Tar
 import Pkg: PackageSpec
 
 import BinaryBuilder.BinaryBuilderBase: available_gcc_builds, available_llvm_builds, getversion
@@ -47,8 +47,9 @@ end
 
 # Test the download stage
 r = HTTP.Router()
-build_tests_dir = joinpath(@__DIR__, "build_tests")
-libfoo_tarball_data = read(`tar czf - -C $(build_tests_dir) libfoo`)
+io = IOBuffer()
+Tar.create(joinpath(build_tests_dir, "libfoo"), pipeline(`gzip -9`, io))
+libfoo_tarball_data = take!(io)
 libfoo_tarball_hash = bytes2hex(sha256(libfoo_tarball_data))
 function serve_tgz(req)
     HTTP.Response(200, libfoo_tarball_data)


### PR DESCRIPTION
In
https://github.com/JuliaPackaging/BinaryBuilder.jl/blob/937c7af962af6745809eb3edaca201b88f1ddc3e/test/wizard.jl#L48-L57
we create a tarball, compute its hash and serve it via HTTP, for use during the tests.  The wizard functions in the tests would download this file, compute the hash and compare with the hash of the original file.  The problem is that we're often observing that the hash of the original file is different from that of the downloaded files, causing a failure in the tests.

Switching to `Tar.jl` to create the tarballs works around #987.