### PR TITLE
Added local build directory @info

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -233,7 +233,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
             # even if we're not planning to register things to it today.
             init_jll_package(src_name, code_dir, deploy_jll_repo)
         else
-            @info("Building and deploying version $(build_version) to ~/.julia/dev/")
+            @info("Building and deploying version $(build_version) to $(code_dir)")
         end
         tag = "$(src_name)-v$(build_version)"
     end

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -227,16 +227,15 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         # Check to see if we've already got a wrapper package within the Registry,
         # choose a version number that is greater than anything else existent.
         build_version = get_next_wrapper_version(src_name, src_version)
-        if verbose
+        if deploy_jll_repo != "local"
             @info("Building and deploying version $(build_version) to $(deploy_jll_repo)")
+            # We need to make sure that the JLL repo at least exists, so that we can deploy binaries to it
+            # even if we're not planning to register things to it today.
+            init_jll_package(src_name, code_dir, deploy_jll_repo)
+        else
+            @info("Building and deploying version $(build_version) to ~/.julia/dev/")
         end
         tag = "$(src_name)-v$(build_version)"
-
-        # We need to make sure that the JLL repo at least exists, so that we can deploy binaries to it
-        # even if we're not planning to register things to it today.
-        if deploy_jll_repo != "local"
-            init_jll_package(src_name, code_dir, deploy_jll_repo)
-        end
     end
 
     # Modify script for debugging


### PR DESCRIPTION
Remove verbose from the `@info` calls about deployment location (seems desirable without verbose). Add a local specific deploy message pointing to `code_dir`. Resolve #1039