### PR TITLE
Catch error from stale GitHub token

### DIFF
--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -8,7 +8,12 @@ function github_auth(;allow_anonymous::Bool=true)
     if !isassigned(_github_auth) || !allow_anonymous && isa(_github_auth[], GitHub.AnonymousAuth)
         # If the user is feeding us a GITHUB_TOKEN token, use it!
         if length(get(ENV, "GITHUB_TOKEN", "")) == 40
-            _github_auth[] = GitHub.authenticate(ENV["GITHUB_TOKEN"])
+            try
+                _github_auth[] = GitHub.authenticate(ENV["GITHUB_TOKEN"])
+            catch e
+                    println(stdout, "The GitHub Token found in \"GITHUB_TOKEN\" has likely expired. We will now attempt to obtain a fresh token for this session.")
+                    _github_auth[] = GitHub.authenticate(obtain_token())
+            end
         else
             if allow_anonymous
                 _github_auth[] = GitHub.AnonymousAuth()

--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -10,7 +10,7 @@ function github_auth(;allow_anonymous::Bool=true)
         try 
             _github_auth[] = GitHub.authenticate(ENV["GITHUB_TOKEN"])
         catch e
-            @warn "GitHub was unable to authenticate using the token from ENV[\"GITHUB_TOKEN\"], we will now request a temporary token."
+            @warn "GitHub was unable to authenticate using the token from ENV[\"GITHUB_TOKEN\"], it may be stale. We will now request a temporary token."
         end
     end
     

--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -10,7 +10,7 @@ function github_auth(;allow_anonymous::Bool=true)
         try 
             _github_auth[] = GitHub.authenticate(ENV["GITHUB_TOKEN"])
         catch e
-            e isa ... || rethrow()
+            @warn "GitHub was unable to authenticate using the token from ENV[\"GITHUB_TOKEN\"], we will now request a temporary token."
         end
     end
     

--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -10,7 +10,11 @@ function github_auth(;allow_anonymous::Bool=true)
         try 
             _github_auth[] = GitHub.authenticate(ENV["GITHUB_TOKEN"])
         catch e
-            @warn "GitHub was unable to authenticate using the token from ENV[\"GITHUB_TOKEN\"], it may be stale. We will now request a temporary token."
+            if occursin("401", e.msg)
+                @warn "GitHub was unable to authenticate using the token from ENV[\"GITHUB_TOKEN\"], it may be stale. We will now request a temporary token."
+            else
+                rethrow()
+            end
         end
     end
     

--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -11,7 +11,7 @@ function github_auth(;allow_anonymous::Bool=true)
             _github_auth[] = GitHub.authenticate(ENV["GITHUB_TOKEN"])
         catch e
             if occursin("401", e.msg)
-                @warn "GitHub was unable to authenticate using the token from ENV[\"GITHUB_TOKEN\"], it may be stale. We will now request a temporary token."
+                @warn "GitHub was unable to authenticate using the token from `ENV[\"GITHUB_TOKEN\"]`, it may be stale. Falling back on alternate authentication methods."
             else
                 rethrow()
             end

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -200,7 +200,23 @@ function yn_prompt(state::WizardState, question::AbstractString, default = :y)
         end
     end
 end
-
+function yn_prompt(question::AbstractString, default= :y)
+    @assert default in (:y, :n)
+    ynstr = default == :y ? "[Y/n]" : "[y/N]"
+    while true
+        print(question, " ", ynstr, ": ")
+        answer = lowercase(strip(readline()))
+        if isempty(answer)
+            return default
+        elseif answer == "y" || answer == "yes"
+            return :y
+        elseif answer == "n" || answer == "no"
+            return :n
+        else
+            println( "Unrecognized answer. Answer `y` or `n`.")
+        end
+    end
+end
 """
     Change the script. This will invalidate all platforms to make sure we later
     verify that they still build with the new script.

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -200,6 +200,7 @@ function yn_prompt(state::WizardState, question::AbstractString, default = :y)
         end
     end
 end
+
 """
     Change the script. This will invalidate all platforms to make sure we later
     verify that they still build with the new script.

--- a/src/wizard/utils.jl
+++ b/src/wizard/utils.jl
@@ -200,23 +200,6 @@ function yn_prompt(state::WizardState, question::AbstractString, default = :y)
         end
     end
 end
-function yn_prompt(question::AbstractString, default= :y)
-    @assert default in (:y, :n)
-    ynstr = default == :y ? "[Y/n]" : "[y/N]"
-    while true
-        print(question, " ", ynstr, ": ")
-        answer = lowercase(strip(readline()))
-        if isempty(answer)
-            return default
-        elseif answer == "y" || answer == "yes"
-            return :y
-        elseif answer == "n" || answer == "no"
-            return :n
-        else
-            println( "Unrecognized answer. Answer `y` or `n`.")
-        end
-    end
-end
 """
     Change the script. This will invalidate all platforms to make sure we later
     verify that they still build with the new script.


### PR DESCRIPTION
This seems like the best way to catch the error. Should I be checking if it's actually an auth error?