### PR TITLE
A simpler way of disabling Codecov commit statuses

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,5 @@ comment: false
 
 coverage:
   status:
-    project:
-      default:
-        threshold: 1%
-        target: 1%
-    patch:
-      default:
-        threshold: 1%
-        target: 1%
+    project: off
+    patch: off


### PR DESCRIPTION
Based on https://docs.codecov.io/docs/commit-status#disabling-a-status