### PR TITLE
Ping the Yggdrasil committer when deploying

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -517,9 +517,16 @@ function register_jll(name, build_version, dependencies, julia_compat;
         * Commit: $(wrapper_commit_hash)
         """
         if is_yggdrasil()
+            commit_hash = yggdrasil_head()
             body *= """
-                    * Revision on Yggdrasil: https://github.com/JuliaPackaging/Yggdrasil/commit/$(yggdrasil_head())
+                    * Revision on Yggdrasil: https://github.com/JuliaPackaging/Yggdrasil/commit/$commit_hash
                     """
+            commit_author_login = get_github_author_login("JuliaPackaging/Yggdrasil", commit_hash; gh_auth=gh_auth)
+            if commit_author_login !== nothing
+                body *= """
+                        * Created by: @$commit_author_login
+                        """
+            end
         end
         params = Dict(
             "base" => "master",
@@ -883,6 +890,15 @@ function download_github_release(download_dir, repo, tag; gh_auth=Wizard.github_
         download(asset["browser_download_url"], joinpath(download_dir, asset["name"]))
     end
     return assets
+end
+
+function get_github_author_login(repository, commit_hash; gh_auth=Wizard.github_auth())
+    try
+        commit = GitHub.commit(repository, commit_hash; auth=gh_auth)
+        commit.author.login
+    catch
+        nothing
+    end
 end
 
 

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -1,6 +1,7 @@
 using JSON
 using UUIDs
-using BinaryBuilder: jll_uuid, build_project_dict
+using GitHub
+using BinaryBuilder: jll_uuid, build_project_dict, get_github_author_login, Wizard
 
 module TestJLL end
 
@@ -21,6 +22,13 @@ module TestJLL end
     @test project["version"] == "1.3.5"
     # Make sure BuildDependency's don't find their way to the project
     @test_throws MethodError build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), BuildDependency("Xorg_util_macros_jll")])
+
+    gh_auth = Wizard.github_auth(;allow_anonymous=true)
+    @test get_github_author_login("JuliaPackaging/Yggdrasil", "invalid_hash"; gh_auth) === nothing
+    @test get_github_author_login("JuliaPackaging/Yggdrasil", "815de56a4440f4e05333c5295d74f1dc9b73ebe3"; gh_auth) === nothing
+    if gh_auth != GitHub.AnonymousAuth()
+        @test get_github_author_login("JuliaPackaging/Yggdrasil", "dea7c3fadad16281ead2427f7ab9b32f1c8cb664"; gh_auth) === "Pangoraw"
+    end
 end
 
 @testset "JLLs - building" begin


### PR DESCRIPTION
Hi!

This adds a mention to the Yggdrasil committer when deploying creating PRs to the registry.
This fails silently because some commits can have no github author if the email address used for the commit doesn't match any GitHub user.

Closes #1056
