### PR TITLE
add newline at end of print_build_tarballs string body

### DIFF
--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -118,6 +118,7 @@ function print_build_tarballs(io::IO, state::WizardState)
 
     # Build the tarballs, and possibly a `build.jl` as well.
     build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies$(kwargs))
+
     """)
 end
 


### PR DESCRIPTION
My workflow with BB is typically `run_wizard()` -> write to local file -> copy file and submit PR manually.

When submitting files directly from the wizard output, the addition of a newline at the end has been noted in review a few times so it seemed reasonable to patch here. I don't think this is an issue with the auto-Yggdrasil PR option or the other option?