### PR TITLE
modify check for existing files that properly splits name and extension

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -161,12 +161,12 @@ function download_source(state::WizardState)
         source_path = joinpath(state.workspace, basename(url))
 
         if isfile(source_path)
-            if occursin(".tar.", basename(source_path))
-                #match everything up to but not including ".tar.*" to strip multiple file extensions
-                m = match(r"^.*(?=(\.tar\.([\s\S]*)))", basename(source_path))
-                name, ext = m.match, m.captures[1]
+            # Try to match everything up to but not including ".tar.*" to strip multiple file extensions
+            m = match(r"^.+(?=(\.tar\.([\s\S]+)))", basename(source_path))
+            name, ext = if isnothing(m)
+                splitext(basename(source_path))
             else
-                name, ext = splitext(basename(source_path))
+                m.match, m.captures[1]
             end
             n = 1
             while isfile(joinpath(state.workspace, "$(name)_$n$ext"))

--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -161,7 +161,13 @@ function download_source(state::WizardState)
         source_path = joinpath(state.workspace, basename(url))
 
         if isfile(source_path)
-            name, ext = splitext(basename(source_path))
+            if occursin(".tar.", basename(source_path))
+                #match everything up to but not including ".tar.*" to strip multiple file extensions
+                m = match(r"^.*(?=(\.tar\.([\s\S]*)))", basename(source_path))
+                name, ext = m.match, m.captures[1]
+            else
+                name, ext = splitext(basename(source_path))
+            end
             n = 1
             while isfile(joinpath(state.workspace, "$(name)_$n$ext"))
                 n += 1

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -202,6 +202,12 @@ end
         libfoo_tarball_hash,
     ]
 
+    #test that two files downloaded with the same name are re-named appropriately 
+    m = match.(r"^.+(?=(\.tar\.([\s\S]+)))", basename.(getfield.(state.source_files,:path)))
+    for cap in m
+        @test cap.captures[1] ∈ BinaryBuilderBase.tar_extensions
+    end
+
     # Test download/install with a broken symlink that used to kill the wizard
     # https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/183
     state = step2_state()


### PR DESCRIPTION
This PR modifies the step in the wizard that modifies file names if duplicated file names exist when downloading sources.

If the files have multiple extensions like `blahh.tar.gz`, `splitext` doesn't split enough and you end up with `foobar.tar_n.gz` which doesn't match [the list of extensions we check against](https://github.com/JuliaPackaging/BinaryBuilderBase.jl/blob/eb8ade82382394ca54a05dc9e7bb27cf2e5ba050/src/Sources.jl#L38-L39). With this, you should now end up with `foobar_n.tar.gz`

closes #1092 