### PR TITLE
[AutoBuild] Add timings of different steps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilder"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"


### PR DESCRIPTION
Output example when building Lua:

```
[ Info: Timings: setup: 16.79s, build: 2.0s, audit: 10.87s, packaging: 0.88s
```

Fix #1111.