### PR TITLE
[wizard] add sort step to products array writing

### DIFF
--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -29,6 +29,7 @@ function print_build_tarballs(io::IO, state::WizardState)
         products_string = "Product[\n]"
     else
         stuff = collect(zip(state.files, state.file_kinds, state.file_varnames))
+        sort!(stuff, by = x -> x[2], rev=true)
         products_string = "[\n    " * join(map(stuff) do x
             file, kind, varname = x
 

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -29,7 +29,7 @@ function print_build_tarballs(io::IO, state::WizardState)
         products_string = "Product[\n]"
     else
         stuff = collect(zip(state.files, state.file_kinds, state.file_varnames))
-        sort!(stuff, by = x -> x[2], rev=true)
+        sort!(stuff, by = x -> x[2], lt=(x,y)-> (x == :library || y ==:other))
         products_string = "[\n    " * join(map(stuff) do x
             file, kind, varname = x
 


### PR DESCRIPTION
This PR adds a sort step to order the tuple of products before writing out in the `deploy` step. This uses `rev=true` so that the order would be `LibraryProduct`, `FrameworkProduct`, `ExecutableProduct`. 
I thought this was handling an `Product[]` directly behind the scenes, but it's just writing the brackets and names as strings, so I had to use tuple sort instead.

Should close #1109