### PR TITLE
Prepend binary name to wizard PRs

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -538,9 +538,9 @@ function register_jll(name, build_version, dependencies, julia_compat;
         upstream_registry_url = "https://github.com/JuliaRegistries/General"
         name_jll = "$(name)_jll"
         if _package_is_registered(upstream_registry_url, name_jll)
-            pr_title = "New version: $(name_jll) v$(build_version)"
+            pr_title = "[$(name)] New version: $(name_jll) v$(build_version)"
         else
-            pr_title = "New package: $(name_jll) v$(build_version)"
+            pr_title = "[$(name)] New package: $(name_jll) v$(build_version)"
         end
         # Open pull request against JuliaRegistries/General
         body = """

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -205,7 +205,7 @@ function yggdrasil_deploy(name, version, patches, build_tarballs_content;
                 "base" => "master",
                 "head" => "$(dirname(fork.full_name)):$(branch_name)",
                 "maintainer_can_modify" => true,
-                "title" => "Wizard recipe: $(name)-v$(version)",
+                "title" => "[$(replace(name, r"_jll$"=> ""))] Wizard recipe: $(name)-v$(version)",
                 "body" => """
                 This pull request contains a new build recipe I built using the BinaryBuilder.jl wizard:
 


### PR DESCRIPTION
Proposal: Make wizard PR titles include binary name in brackets, e.g. "[jemalloc] Wizard recipe: jemalloc-v5.2.1 (#4064)".