### PR TITLE
update docs on debug flag

### DIFF
--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -45,7 +45,7 @@ You can always build a JLL package on your machine with the `--deploy` flag to t
 A common use case is that you want to build a JLL package for, say, `Libfoo`, that will be used as dependency to build `Quxlib`, and you want to make sure that building both `Libfoo` and `Quxlib` will work before submitting all the pull requests to [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/).  You can prepare the `build_tarballs.jl` script for `Libfoo` and then build and deploy it with
 
 ```
-julia build_tarballs.jl --debug --verbose --deploy="MY_USERNAME/Libfoo_jll.jl"
+julia build_tarballs.jl --debug=error --verbose --deploy="MY_USERNAME/Libfoo_jll.jl"
 ```
 
 replacing `MY_USERNAME` with your GitHub username: this will build the tarballs for all the platforms requested and upload them to a release of the `MY_USERNAME/Libfoo_jll.jl`, where the JLL package will also be created.  As explained above, you can pass argument the list of triplets of the platforms for you which you want to build the tarballs, in case you want to compile only some of them.  In the Julia REPL, you can install this package as any unregistered package with
@@ -69,7 +69,7 @@ Since this package is unregistered, you have to use the full [`PackageSpec`](htt
 You can of course in turn build and deploy this package with
 
 ```
-julia build_tarballs.jl --debug --verbose --deploy="MY_USERNAME/Quxlib_jll.jl"
+julia build_tarballs.jl --debug=error --verbose --deploy="MY_USERNAME/Quxlib_jll.jl"
 ```
 
 Note that `PackageSpec` can also point to a local path: e.g., `PackageSpec(; name="Libfoo_jll", uuid="...", path="/home/myname/.julia/dev/Libfoo_jll")`.  This is particularly useful when [building a custom JLL package locally](@ref), instead of deploying it to a remote Git repository.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,13 +33,13 @@ julia build_tarballs.jl --help
 ```
 You can build the tarballs with
 ```
-julia build_tarballs.jl --debug --verbose
+julia build_tarballs.jl --debug=error --verbose
 ```
-The `--debug` option will drop you into the BinaryBuilder interactive shell if an error occurs.  If the build fails, after finding out the steps needed to fix the build you have to manually update the script in `build_tarballs.jl`.  You should run again the above command to make sure that everything is actually working.
+The `--debug=error` option will drop you into the BinaryBuilder interactive shell if an error occurs.  If the build fails, after finding out the steps needed to fix the build you have to manually update the script in `build_tarballs.jl`.  You should run again the above command to make sure that everything is actually working.
 
 Since `build_tarballs.jl` takes as argument the comma-separated list of [triplets](@ref Platforms) for which to build the tarballs, you can select only a few of them.  For example, with
 ```
-julia build_tarballs.jl --debug --verbose aarch64-linux-musl,arm-linux-musleabihf
+julia build_tarballs.jl --debug=error --verbose aarch64-linux-musl,arm-linux-musleabihf
 ```
 you'll run the build script only for the `aarch64-linux-musl` and `arm-linux-musleabihf` target platforms.
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -21,7 +21,7 @@ state = BinaryBuilder.Wizard.load_wizard_state() # select 'resume'
 BinaryBuilder.Wizard.print_build_tarballs(stdout, state)
 ```
 
-The build script may then be edited as appropriate -- for example to disable the failing platform -- and rerun directly with `julia  build_tarballs.jl --debug --verbose` (see [manual build documentation](https://docs.binarybuilder.org/dev/#Manually-create-or-edit-build_tarballs.jl)) to debug and complete *without* starting from scratch.
+The build script may then be edited as appropriate -- for example to disable the failing platform -- and rerun directly with `julia  build_tarballs.jl --debug=error --verbose` (see [manual build documentation](https://docs.binarybuilder.org/dev/#Manually-create-or-edit-build_tarballs.jl)) to debug and complete *without* starting from scratch.
 
 ### Header files of the dependencies can't be found
 


### PR DESCRIPTION
--debug by itself no longer drops the user to a shell.
Replace --debug with --debug=error in the documentation.