### PR TITLE
[Audit] Ignore status of some audit processes

### DIFF
--- a/src/auditor/compiler_abi.jl
+++ b/src/auditor/compiler_abi.jl
@@ -173,7 +173,7 @@ function cppfilt(symbol_names::Vector, platform::AbstractPlatform; strip_undersc
     output = IOBuffer()
     mktempdir() do dir
         ur = preferred_runner()(dir; cwd="/workspace/", platform=platform)
-        cmd = `/opt/bin/$(triplet(ur.platform))/c++filt`
+        cmd = Cmd(`/opt/bin/$(triplet(ur.platform))/c++filt`; ignorestatus=true)
         if strip_underscore
             cmd = `$(cmd) --strip-underscore`
         end

--- a/src/auditor/instruction_set.jl
+++ b/src/auditor/instruction_set.jl
@@ -41,7 +41,7 @@ function instruction_mnemonics(path::AbstractString, platform::AbstractPlatform)
     else
         objdump_cmd = "\${target}-objdump -d $(basename(path))"
     end
-    run_interactive(ur, `/bin/bash -c "$(objdump_cmd)"`; stdout=output, stderr=devnull)
+    run_interactive(ur, Cmd(`/bin/bash -c "$(objdump_cmd)"`; ignorestatus=true); stdout=output, stderr=devnull)
     seekstart(output)
 
     for line in eachline(output)


### PR DESCRIPTION
We we relying on the fact that when doing
```julia
run_interactive(...; stdout=IOBuffer())
```
the exit status of the command would be accidentally ignored, now fixed in
`BinaryBuilderBase`.  With this change we ensure that the exit status is always
ignored.