### PR TITLE
[Autobuild] Add log file prompt

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -792,7 +792,7 @@ function autobuild(dir::AbstractString,
         if !did_succeed
             if debug
                 log_files = String[]
-                for (root, dirs, files) in walkdir(prefix.path * "/srcdir")
+                for (root, dirs, files) in walkdir(joinpath(prefix.path, "srcdir"))
                     for file in files
                         if endswith(file, ".log")
                             push!(log_files, joinpath(root, file))

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -618,7 +618,7 @@ function compose_debug_prompt(sandbox_dir, project_dir)
 
         debug_shell_prompt = """
         Build failed, the following log files were generated:
-            - $log_files_str
+          - $log_files_str
 
         Launching debug shell:
         """

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -801,11 +801,7 @@ function autobuild(dir::AbstractString,
                 end
                 
                 if length(log_files) > 0
-                    if length(log_files) > 1
-                        log_files_str = join(log_files, "\n    ")
-                    elseif length(log_files) == 1
-                        log_files_str = log_files[1]
-                    end
+                    log_files_str = join(log_files, "\n    ")
 
                     debug_shell_prompt = """
                     Build failed, the following log files were generated:

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -791,7 +791,7 @@ function autobuild(dir::AbstractString,
         end
         if !did_succeed
             if debug
-                log_files = []
+                log_files = String[]
                 for (root, dirs, files) in walkdir(prefix.path * "/srcdir")
                     for file in files
                         if endswith(file, ".log")

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -614,11 +614,11 @@ function compose_debug_prompt(sandbox_dir, project_dir)
     end
     
     if length(log_files) > 0
-        log_files_str = join(log_files, "\n    ")
+        log_files_str = join(log_files, "\n    - ")
 
         debug_shell_prompt = """
         Build failed, the following log files were generated:
-            $log_files_str
+            - $log_files_str
 
         Launching debug shell:
         """

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -614,7 +614,7 @@ function compose_debug_prompt(sandbox_dir, project_dir)
     end
     
     if length(log_files) > 0
-        log_files_str = join(log_files, "\n    - ")
+        log_files_str = join(log_files, "\n  - ")
 
         debug_shell_prompt = """
         Build failed, the following log files were generated:

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -799,10 +799,6 @@ function autobuild(dir::AbstractString,
                         end
                     end
                 end
-
-                debug_shell_prompt = """
-                Launching debug shell now:
-                """                
                 
                 if length(log_files) > 0
                     if length(log_files) > 1
@@ -811,11 +807,14 @@ function autobuild(dir::AbstractString,
                         log_files_str = log_files[1]
                     end
 
-                    build_files_prompt = """
+                    debug_shell_prompt = """
                     Build failed, the following log files were generated:
                         $log_files_str
+
+                    Launching debug shell:
                     """
-                    debug_shell_prompt = build_files_prompt * debug_shell_prompt
+                else
+                    debug_shell_prompt = "Build failed, launching debug shell:"
                 end
 
                 @warn(debug_shell_prompt)

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -795,7 +795,7 @@ function autobuild(dir::AbstractString,
                 for (root, dirs, files) in walkdir(joinpath(prefix.path, "srcdir"))
                     for file in files
                         if endswith(file, ".log")
-                            push!(log_files, joinpath(root, file))
+                            push!(log_files, replace(joinpath(root, file), "$dir/" => ""))
                         end
                     end
                 end

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -817,7 +817,7 @@ function autobuild(dir::AbstractString,
         end
         if !did_succeed
             if debug
-                # Print debug promt and paths to any generated log files
+                # Print debug prompt and paths to any generated log files
                 debug_shell_prompt = compose_debug_prompt(prefix.path, dir)
                 @warn(debug_shell_prompt)
                 run_interactive(ur, `/bin/bash -l -i`)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -102,7 +102,7 @@ end
 
 
         # Test that debug prompt generation works
-        @testset "Check debug prompt logic"
+        @testset "Check debug prompt logic" begin
             @test "Build failed, launching debug shell:" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
             logfile_path = joinpath(build_path, "srcdir", "errors.log")
             open(logfile_path, "w") do io

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -108,7 +108,7 @@ end
             open(logfile_path, "w") do io
                 write(io, "log message")
             end
-            @test "Build failed, the following log files were generated:\n    $(replace(logfile_path, "$temp_path/" => ""))\n\nLaunching debug shell:\n" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
+            @test "Build failed, the following log files were generated:\n    - $(replace(logfile_path, "$temp_path/" => ""))\n\nLaunching debug shell:\n" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
             rm(logfile_path)
         end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -108,7 +108,7 @@ end
             open(logfile_path, "w") do io
                 write(io, "log message")
             end
-            @test "Build failed, the following log files were generated:\n    - $(replace(logfile_path, "$temp_path/" => ""))\n\nLaunching debug shell:\n" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
+            @test "Build failed, the following log files were generated:\n  - $(replace(logfile_path, "$temp_path/" => ""))\n\nLaunching debug shell:\n" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
             rm(logfile_path)
         end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -100,6 +100,18 @@ end
         @test isfile(hist_file)
         @test isfile(env_file)
 
+
+        # Test that debug prompt generation works
+        @testset "Check debug prompt logic"
+            @test "Build failed, launching debug shell:" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
+            logfile_path = joinpath(build_path, "srcdir", "errors.log")
+            open(logfile_path, "w") do io
+                write(io, "log message")
+            end
+            @test "Build failed, the following log files were generated:\n    $(replace(logfile_path, "$temp_path/" => ""))\n\nLaunching debug shell:\n" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
+            rm(logfile_path)
+        end
+
         # Test that exit 1 is in .bash_history
         @test occursin("\nexit 1\n", read(open(hist_file), String))
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -106,7 +106,7 @@ end
             @test "Build failed, launching debug shell:" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
             logfile_path = joinpath(build_path, "srcdir", "errors.log")
             open(logfile_path, "w") do io
-                write(io, "log message")
+                write(io, "sample log message")
             end
             @test "Build failed, the following log files were generated:\n  - $(replace(logfile_path, "$temp_path/" => ""))\n\nLaunching debug shell:\n" == BinaryBuilder.compose_debug_prompt(build_path, temp_path)
             rm(logfile_path)


### PR DESCRIPTION
Resolves #1149

If *.log files are present, yields:

```bash
┌ Warning: Build failed, the following log files were generated:
│  - build/x86_64-linux-musl/4Rb7HiTe/srcdir/curl-7.81.0/config.log
│ 
│ Launching debug shell:
└ @ BinaryBuilder ~/.julia/dev/BinaryBuilder/src/AutoBuild.jl:816
```

Otherwise (in case of no log files), no change from current version.