### PR TITLE
README.md: update latest -> dev in doc URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://dev.azure.com/JuliaPackaging/BinaryBuilder.jl/_apis/build/status/JuliaPackaging.BinaryBuilder.jl?branchName=master)](https://dev.azure.com/JuliaPackaging/BinaryBuilder.jl/_build/latest?definitionId=2&branchName=master) [![codecov.io](http://codecov.io/github/JuliaPackaging/BinaryBuilder.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaPackaging/BinaryBuilder.jl?branch=master) 
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliapackaging.github.io/BinaryBuilder.jl/stable)
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliapackaging.github.io/BinaryBuilder.jl/dev)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://docs.binarybuilder.org/stable)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://docs.binarybuilder.org/dev)
 
 > "Yea, though I walk through the valley of the shadow of death, I will fear no evil"
 
@@ -24,7 +24,7 @@ BinaryBuilder.run_wizard()
 
 4. The output of a build is a JLL package (typically hosted within the [JuliaBinaryWrappers](https://github.com/JuliaBinaryWrappers/) GitHub organization) which can be added to packages just like any other Julia package.  The JLL package will export bindings for all products defined within the build recipe.
 
-For more information, see the documentation for this package, viewable either directly in markdown within the [`docs/src`](docs/src) folder within this repository, or [online](https://juliapackaging.github.io/BinaryBuilder.jl/dev).
+For more information, see the documentation for this package, viewable either directly in markdown within the [`docs/src`](docs/src) folder within this repository, or [online](https://docs.binarybuilder.org).
 
 # Philosophy
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://dev.azure.com/JuliaPackaging/BinaryBuilder.jl/_apis/build/status/JuliaPackaging.BinaryBuilder.jl?branchName=master)](https://dev.azure.com/JuliaPackaging/BinaryBuilder.jl/_build/latest?definitionId=2&branchName=master) [![codecov.io](http://codecov.io/github/JuliaPackaging/BinaryBuilder.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaPackaging/BinaryBuilder.jl?branch=master) 
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliapackaging.github.io/BinaryBuilder.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliapackaging.github.io/BinaryBuilder.jl/latest)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliapackaging.github.io/BinaryBuilder.jl/dev)
 
 > "Yea, though I walk through the valley of the shadow of death, I will fear no evil"
 
@@ -24,7 +24,7 @@ BinaryBuilder.run_wizard()
 
 4. The output of a build is a JLL package (typically hosted within the [JuliaBinaryWrappers](https://github.com/JuliaBinaryWrappers/) GitHub organization) which can be added to packages just like any other Julia package.  The JLL package will export bindings for all products defined within the build recipe.
 
-For more information, see the documentation for this package, viewable either directly in markdown within the [`docs/src`](docs/src) folder within this repository, or [online](https://juliapackaging.github.io/BinaryBuilder.jl/latest).
+For more information, see the documentation for this package, viewable either directly in markdown within the [`docs/src`](docs/src) folder within this repository, or [online](https://juliapackaging.github.io/BinaryBuilder.jl/dev).
 
 # Philosophy
 

--- a/docs/src/build_tips.md
+++ b/docs/src/build_tips.md
@@ -194,9 +194,9 @@ You need to understand the build process of package you want to compile in order
 
 Generated tarballs should come with the license of the library that you want to install.  If at the end of a successful build there is only one directory inside `${WORKSPACE}/srcdir`, BinaryBuilder will look into it for files with typical names for license (like `LICENSE`, `COPYRIGHT`, etc... with some combinations of extensions) and automatically install them to `${prefix}/share/licenses/${SRC_NAME}/`.  If in the final tarball there are no files in this directory a warning will be issued, to remind you to provide a license file.
 
-If the license file is not automatically installed (for example because there is more than one directory in `${WORKSPACE}/srcdir` or because the file name doesn't match the expected pattern) you have to manually install the file.  In the build script you can use the `install_license` command.  See the [Utilities in the build environment](@ref) section below.
+If the license file is not automatically installed (for example because there is more than one directory in `${WORKSPACE}/srcdir` or because the file name doesn't match the expected pattern) you have to manually install the file.  In the build script you can use the `install_license` command.  See the [Utilities in the build environment](@ref utils_build_env) section below.
 
-## Utilities in the build environment
+## [Utilities in the build environment](@id utils_build_env)
 
 In addition to the standard Unix tools, in the build environment there are some extra commands provided by BinaryBuilder.  Here is a list of some of these commands:
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -63,7 +63,7 @@ checking build system type... Invalid configuration `x86_64-linux-musl': system 
 configure: error: /bin/sh ./config.sub x86_64-linux-musl failed
 ```
 
-The `BinaryBuilder` environment provides the utility [`update_configure_scripts`](https://juliapackaging.github.io/BinaryBuilder.jl/dev/build_tips/#Utilities-in-the-build-environment-1) to automatically update these scripts, call it before `./configure`:
+The `BinaryBuilder` environment provides the utility [`update_configure_scripts`](@ref utils_build_env) to automatically update these scripts, call it before `./configure`:
 
 ```sh
 update_configure_scripts
@@ -118,7 +118,7 @@ make -j${nproc}
 make install
 ```
 
-See for example the builder for [Giflib](https://github.com/JuliaPackaging/Yggdrasil/blob/78fb3a7b4d00f3bc7fd2b1bcd24e96d6f31d6c4b/G/Giflib/build_tarballs.jl).  If you need to regenerate `configure`, you'll probably need to run [`update_configure_scripts`](https://juliapackaging.github.io/BinaryBuilder.jl/dev/build_tips/#Utilities-in-the-build-environment-1) to make other platforms work as well.
+See for example the builder for [Giflib](https://github.com/JuliaPackaging/Yggdrasil/blob/78fb3a7b4d00f3bc7fd2b1bcd24e96d6f31d6c4b/G/Giflib/build_tarballs.jl).  If you need to regenerate `configure`, you'll probably need to run [`update_configure_scripts`](@ref utils_build_env) to make other platforms work as well.
 
 ## FreeBSD
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1347,7 +1347,7 @@ function build_jll_package(src_name::String,
         end
         println(io)
         println(io)
-        println(io,"For more details about JLL packages and how to use them, see `BinaryBuilder.jl` [documentation](https://juliapackaging.github.io/BinaryBuilder.jl/dev/jll/).")
+        println(io,"For more details about JLL packages and how to use them, see `BinaryBuilder.jl` [documentation](https://docs.binarybuilder.org/stable/jll/).")
         println(io)
         if length(sources) > 0
             # `sources` can be empty, and it is for some HelloWorld examples


### PR DESCRIPTION
This was changed deprecated in Documenter.jl 0.20.0 and dropped in 0.24.0
