### PR TITLE
Replace files when uploading to github.

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -437,7 +437,7 @@ function upload_to_github_releases(repo, tag, path; gh_auth=Wizard.github_auth(;
     for attempt in 1:attempts
         try
             ghr() do ghr_path
-                run(`$ghr_path -u $(dirname(repo)) -r $(basename(repo)) -t $(gh_auth.token) $(tag) $(path)`)
+                run(`$ghr_path -u $(dirname(repo)) -r $(basename(repo)) -t $(gh_auth.token) -replace $(tag) $(path)`)
             end
             return
         catch


### PR DESCRIPTION
When invoking `build_artifacts` multiple times, each `--deploy-bin` will try to upload every file in `products`. Ideally, we only upload the products for this specific invocation, just like `--deploy-jll` only commits those changes, but that's not how `ghr` works. As a stop-gap measure, just replace previously-existing artifacts.

Note that this easily arises when using `--deploy`, which *needs* to be passed to every `build_tarballs` call or the JLL changes wouldn't be committed.

Example of this occurring:

```
$ jl --project build_tarballs.jl --debug --verbose x86_64-linux-gnu-cxx11-llvm+12,x86_64-linux-gnu-cxx11-llvm+13 --deploy=maleadt/SPIRV_LLVM_Translator_unified_jll.jl

...

[ Info: Deploying binaries to release SPIRV_LLVM_Translator_unified-v0.1.0+0 on maleadt/SPIRV_LLVM_Translator_unified_jll.jl via `ghr`...
==> Create a new release
--> Uploading: SPIRV_LLVM_Translator_unified.v0.1.0.x86_64-linux-gnu-cxx11-llvm+12.tar.gz

but the during the second build

[ Info: Deploying binaries to release SPIRV_LLVM_Translator_unified-v0.1.0+0 on maleadt/SPIRV_LLVM_Translator_unified_jll.jl via `ghr`...
WARNING: found release (SPIRV_LLVM_Translator_unified-v0.1.0+0). Use existing one.
--> Uploading: SPIRV_LLVM_Translator_unified.v0.1.0.x86_64-linux-gnu-cxx11-llvm+13.tar.gz
--> Uploading: SPIRV_LLVM_Translator_unified.v0.1.0.x86_64-linux-gnu-cxx11-llvm+12.tar.gz
Failed to upload one of assets: one of the goroutines failed: failed to upload asset: /home/tim/Julia/tools/Yggdrasil/S/SPIRV_LLVM_Translator_unified/products/SPIRV_LLVM_Translator_unified.v0.1.0.x86_64-linux-gnu-cxx11-llvm+12.tar.gz: failed to upload release asset: /home/tim/Julia/tools/Yggdrasil/S/SPIRV_LLVM_Translator_unified/products/SPIRV_LLVM_Translator_unified.v0.1.0.x86_64-linux-gnu-cxx11-llvm+12.tar.gz: POST https://uploads.github.com/repos/maleadt/SPIRV_LLVM_Translator_unified_jll.jl/releases/57566045/assets?name=SPIRV_LLVM_Translator_unified.v0.1.0.x86_64-linux-gnu-cxx11-llvm%2B12.tar.gz: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```

Ref https://github.com/JuliaPackaging/Yggdrasil/pull/4291