### PR TITLE
[Auditor] Add more ignored libraries

### DIFF
--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -340,7 +340,7 @@ function check_dynamic_linkage(oh, prefix, bin_files;
         libs = find_libraries(oh)
         ignored_libraries = String[]
         for libname in keys(libs)
-            if should_ignore_lib(libname, oh)
+            if should_ignore_lib(libname, oh, platform)
                 push!(ignored_libraries, libname)
                 continue
             end

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -205,6 +205,7 @@ function should_ignore_lib(lib, ::MachOHandle, platform::AbstractPlatform)
         "foundation",
         "iokit",
         "security",
+        "systemconfiguration",
     ]
     return lowercase(basename(lib)) in ignore_libs
 end
@@ -242,6 +243,8 @@ function should_ignore_lib(lib, ::COFFHandle, platform::AbstractPlatform)
         "msimg32.dll",
         "dnsapi.dll",
         "wsock32.dll",
+        "psapi.dll",
+        "bcrypt.dll",
 
         # Compiler support libraries
         "libgcc_s_seh-1.dll",

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -150,7 +150,7 @@ function is_for_platform(h::ObjectHandle, platform::AbstractPlatform)
 end
 
 # These are libraries we should straight-up ignore, like libsystem on OSX
-function should_ignore_lib(lib, ::ELFHandle)
+function should_ignore_lib(lib, ::ELFHandle, platform::AbstractPlatform)
     ignore_libs = [
         # dynamic loaders
         "ld-linux-x86-64.so.2",
@@ -184,18 +184,34 @@ function should_ignore_lib(lib, ::ELFHandle)
         "libthr.so.3",
         "libpthread.so.0",
     ]
+    if Sys.isfreebsd(platform)
+        push!(ignore_libs,
+              # From FreeBSD SDK
+              "libdevstat.sos.7",
+              "libexecinfo.so.1",
+              "libkvm.so.7",
+              "libz.so.6",
+              )
+    end
     return lowercase(basename(lib)) in ignore_libs
 end
-function should_ignore_lib(lib, ::MachOHandle)
+function should_ignore_lib(lib, ::MachOHandle, platform::AbstractPlatform)
     ignore_libs = [
         "libsystem.b.dylib",
         # This is not built by clang or GCC, so we leave it as a system library
         "libc++.1.dylib",
         "libresolv.9.dylib",
+        # Other libraries in the SDK
+        "libz.1.dylib",
+        # Frameworks in the SDK
+        "courefoundation",
+        "foundation",
+        "iokit",
+        "security",
     ]
     return lowercase(basename(lib)) in ignore_libs
 end
-function should_ignore_lib(lib, ::COFFHandle)
+function should_ignore_lib(lib, ::COFFHandle, platform::AbstractPlatform)
     ignore_libs = [
         # Core runtime libs
         "ntdll.dll",
@@ -228,6 +244,7 @@ function should_ignore_lib(lib, ::COFFHandle)
         "winhttp.dll",
         "msimg32.dll",
         "dnsapi.dll",
+        "wsock32.dll",
 
         # Compiler support libraries
         "libgcc_s_seh-1.dll",

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -190,7 +190,6 @@ function should_ignore_lib(lib, ::ELFHandle, platform::AbstractPlatform)
               "libdevstat.sos.7",
               "libexecinfo.so.1",
               "libkvm.so.7",
-              "libz.so.6",
               )
     end
     return lowercase(basename(lib)) in ignore_libs
@@ -201,10 +200,8 @@ function should_ignore_lib(lib, ::MachOHandle, platform::AbstractPlatform)
         # This is not built by clang or GCC, so we leave it as a system library
         "libc++.1.dylib",
         "libresolv.9.dylib",
-        # Other libraries in the SDK
-        "libz.1.dylib",
         # Frameworks in the SDK
-        "courefoundation",
+        "corefoundation",
         "foundation",
         "iokit",
         "security",


### PR DESCRIPTION
Our audit logs contain lots of references to system libraries.  I've been
meaning to do this for a long time, I'll probably keep this open for some more
time to collect more libraries we spot into the wild, but I wanted to open this
PR to make sure this is a good idea.  CC: @staticfloat