### PR TITLE
Strip URL parameters from names on disk

### DIFF
--- a/src/wizard/obtain_source.jl
+++ b/src/wizard/obtain_source.jl
@@ -109,7 +109,8 @@ function download_source(state::WizardState)
         close(repo)
     else
         # Download the source tarball
-        source_path = joinpath(state.workspace, basename(url))
+        basename_without_urlparams(url) = first(split(basename(url), "?"))
+        source_path = joinpath(state.workspace, basename_without_urlparams(url))
 
         if isfile(source_path)
             # Try to match everything up to but not including ".tar.*" to strip multiple file extensions


### PR DESCRIPTION
We don't really want to create things called `file.zip?raw=true`,
especially as that may screw up our Archive detection later on.