### PR TITLE
list supported triplets in --help

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -116,6 +116,9 @@ const BUILD_HELP = (
         julia build_tarballs.jl x86_64-linux-gnu,i686-linux-gnu
             This builds two tarballs for the two platforms given, with a
             minimum of output messages.
+
+    Supported Platforms:
+        $(join(map(triplet, supported_platforms()), "\n    "))
     """
 )
 


### PR DESCRIPTION
This adds the following to the help output for quick reference:

```
Supported Platforms:
    i686-linux-gnu
    x86_64-linux-gnu
    aarch64-linux-gnu
    armv6l-linux-gnueabihf
    armv7l-linux-gnueabihf
    powerpc64le-linux-gnu
    i686-linux-musl
    x86_64-linux-musl
    aarch64-linux-musl
    armv6l-linux-musleabihf
    armv7l-linux-musleabihf
    x86_64-apple-darwin
    aarch64-apple-darwin
    x86_64-unknown-freebsd
    i686-w64-mingw32
    x86_64-w64-mingw32
```