### PR TITLE
[AutoBuild] Disallow prerelease numbers in versions of JLLs

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -756,7 +756,7 @@ function autobuild(dir::AbstractString,
 
     # If the user passed in a src_version with a build number, bail out
     if any(!isempty, (src_version.prerelease, src_version.build))
-        error("Will not build with a `src_version` that has not the format `major.minor.patch`!  Do not set prerelease or build numbers.")
+        error("Will not build with a `src_version` that does not have the format `major.minor.patch`!  Do not set prerelease or build numbers.")
     end
 
     # We must prepare our sources.  Download them, hash them, etc...

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -755,8 +755,8 @@ function autobuild(dir::AbstractString,
     end
 
     # If the user passed in a src_version with a build number, bail out
-    if src_version.build != ()
-        error("Will not build with a `src_version` that has a build number already specified!")
+    if any(!isempty, (src_version.prerelease, src_version.build))
+        error("Will not build with a `src_version` that has not the format `major.minor.patch`!  Do not set prerelease or build numbers.")
     end
 
     # We must prepare our sources.  Download them, hash them, etc...

--- a/test/building.jl
+++ b/test/building.jl
@@ -291,11 +291,21 @@ end
             )
         end
 
-        # Test that manually specifying a build number in our src_version is an error()
+        # Test that manually specifying prerelease or build number in our src_version is an error()
         @test_throws ErrorException autobuild(
             build_path,
             "badopenssl",
             v"1.1.1+c",
+            GitSource[],
+            "true",
+            [HostPlatform()],
+            Product[],
+            Dependency[],
+        )
+        @test_throws ErrorException autobuild(
+            build_path,
+            "test",
+            v"1.2.3-4",
             GitSource[],
             "true",
             [HostPlatform()],


### PR DESCRIPTION
As a matter of fact Pkg doesn't like them, I think it's better to automatically
error our instead of having to tell users that they shouldn't use them.

Recent cases on Yggdrasil: https://github.com/JuliaPackaging/Yggdrasil/pull/5345#discussion_r953729854 and https://github.com/JuliaPackaging/Yggdrasil/pull/5344#discussion_r953604740.