### PR TITLE
[AutoBuild] Precompile `__init__` in generated JLL wrappers

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1357,6 +1357,7 @@ function build_jll_package(src_name::String,
 
             print(io, """
             end  # __init__()
+            precompile(__init__, ())
             """)
         end
     end


### PR DESCRIPTION
Suggested by @vchuravy.  I haven't studied the impact of this though.