### PR TITLE
[Auditor] Add a pass to normalise timestamps in Windows import libraries

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ jobs:
   steps:
   - bash: |
       set -e
+      $(JULIA) -e 'using Pkg; Pkg.gc()'
       $(JULIA) --check-bounds=yes --inline=yes -e 'using Pkg; Pkg.Registry.update(); Pkg.instantiate(); Pkg.test(coverage=true)'
       $(JULIA) -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())' || true
     name: Test

--- a/src/Auditor.jl
+++ b/src/Auditor.jl
@@ -201,7 +201,9 @@ function audit(prefix::Prefix, src_name::AbstractString = "";
             continue
         end
         # remove it
-        @info("Removing libtool file $f")
+        if verbose
+            @info("Removing libtool file $f")
+        end
         rm(f; force=true)
     end
 
@@ -245,6 +247,16 @@ function audit(prefix::Prefix, src_name::AbstractString = "";
                 mv(f, joinpath(prefix, "bin", basename(f)))
             end
         end
+
+        # Normalise timestamp of Windows import libraries.
+        import_libraries = collect_files(prefix, endswith(".dll.a"))
+        for implib in import_libraries
+            if verbose
+                @info("Normalising timestamps in import library $(implib)")
+            end
+            normalise_implib_timestamp(implib)
+        end
+
     end
 
     # Check that we're providing a license file

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -731,10 +731,10 @@ end
 # * https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1232
 # * https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1245
 @testset "Auditor - Reproducible libraries on Windows" begin
-    platform = Platform("x86_64", "windows")
+    platform = Platform("i686", "windows")
     expected_git_shas = Dict(
-        v"4" => Base.SHA1("5084adf84a54c21699adf0e48dfabb260823871a"),
-        v"6" => Base.SHA1("d9e0fb2c60e0f3bc49633827d1d0bd374f55fef8"),
+        v"4" => Base.SHA1("64017544630a472081ba10879e58901d5e3b53a0"),
+        v"6" => Base.SHA1("31afae67c528151860c18128696b19c85309b556"),
     )
     @testset "gcc version $(gcc_version)" for gcc_version in (v"4", v"6")
         mktempdir() do build_path


### PR DESCRIPTION
This should ensure reproducibility of import libraries.  Fix #1245

I'm sure the replacement could be done in a somewhat nicer way by working with the raw bytes, but the regexp replacement is so simple.