### PR TITLE
Add note about Meson GCC toolchain to `build_tips.md`

### DIFF
--- a/docs/src/build_tips.md
+++ b/docs/src/build_tips.md
@@ -165,6 +165,8 @@ For these target systems Clang is the default compiler, however some programs ma
 
 For programs built with CMake (see the [CMake build](#CMake-builds-1) section) you can use the GCC toolchain file that is in `${CMAKE_TARGET_TOOLCHAIN%.*}_gcc.cmake`.
 
+For programs built with Meson (see the [Meson build](#Meson-builds-1) section) you can use the GCC toolchain file that is in `${MESON_TARGET_TOOLCHAIN%.*}_gcc.meson`.
+
 If the project that you want to build uses the GNU Build System (also known as the Autotools), there isn't an automatic switch to use GCC, but you have to set the appropriate variables.  For example, this setting can be used to build most C/C++ programs with GCC for FreeBSD and macOS:
 ```sh
 if [[ "${target}" == *-freebsd* ]] || [[ "${target}" == *-apple-* ]]; then


### PR DESCRIPTION
This change adds a note about where to find Meson GCC toolchain files.

When I first read this section as-is, I assumed that CMake was the only build system with GCC-specific toolchain files which led to a fruitless effort to make `CC=gcc CXX=g++ meson` work.