### PR TITLE
Allow disabling the `isidentifier` check in `build_tarballs`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilder"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -169,6 +169,10 @@ supported ones. A few additional keyword arguments are accept:
   JLL wrapper to select the artifact. Note that this option requires the Julia
   compatibility `julia_compat` to be 1.6 or higher.
 
+* `validate_name` ensures that `src_name` constitutes a valid Julia identifier.
+  Since the generated JLL package is named according to `src_name`, this should
+  only be set to `false` if you _really_ know what you're doing.
+
 !!! note
 
     The `init_block` and `augment_platform_block` keyword arguments are experimental
@@ -178,7 +182,7 @@ supported ones. A few additional keyword arguments are accept:
 function build_tarballs(ARGS, src_name, src_version, sources, script,
                         platforms, products, dependencies;
                         julia_compat::String = DEFAULT_JULIA_VERSION_SPEC,
-                        kwargs...)
+                        validate_name::Bool=true, kwargs...)
     @nospecialize
     # See if someone has passed in `--help`, and if so, give them the
     # assistance they so clearly long for
@@ -187,7 +191,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         return nothing
     end
 
-    if !Base.isidentifier(src_name)
+    if validate_name && !Base.isidentifier(src_name)
         error("Package name \"$(src_name)\" is not a valid identifier")
     end
 

--- a/test/building.jl
+++ b/test/building.jl
@@ -360,6 +360,10 @@ end
     end
 
     @test_throws ErrorException build_tarballs(String[], "", v"1.0", GitSource[], "", supported_platforms(; experimental=true), LibraryProduct[], Dependency[])
+
+    @test_throws ErrorException build_tarballs(String[], "1nvalid-name :(", v"4.20.69",
+                                               GitSource[], "", supported_platforms(),
+                                               LibraryProduct[], Dependency[])
 end
 
 @testset "AnyPlatform" begin


### PR DESCRIPTION
Validation of the field that will determine the name of the generated JLL package is what you want 99.9% of the time. But that other 0.1% of the time is `Yggdrasil/0_RootFS/PlatformSupport/build_tarballs.jl`: each invocation of the script specifies a separate platform, the triplet of which gets embedded in the name. Unfortunately e.g. `PlatformSupport-x86_64-unknown-freebsd13.2` is not a valid identifier, so building PlatformSupport with recent BinaryBuilder fails.