### PR TITLE
Remove separate source_urls wizard field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
 ArgParse = "1.1"
-BinaryBuilderBase = "1.20"
+BinaryBuilderBase = "1.26"
 GitHub = "5.1"
 HTTP = "0.8, 0.9, 1"
 JLD2 = "0.1.6, 0.2, 0.3, 0.4"

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -1,15 +1,13 @@
 function print_build_tarballs(io::IO, state::WizardState)
-    urlfiles = zip(state.source_urls, state.source_files)
-
-    sources_strings = map(urlfiles) do x
+    sources_strings = map(state.source_files) do source
         # Try to be smart and automatically replace version number with `$(version)`.
-        url_string = replace(repr(x[1]), string(state.version) => "\$(version)")
-        if endswith(x[1], ".git")
-            "GitSource($(url_string), $(repr(x[2].hash)))"
-        elseif any(endswith(x[1], ext) for ext in BinaryBuilderBase.archive_extensions)
-            "ArchiveSource($(url_string), $(repr(x[2].hash)))"
+        url_string = replace(repr(source.url), string(state.version) => "\$(version)")
+        if endswith(source.url, ".git")
+            "GitSource($(url_string), $(repr(source.hash)))"
+        elseif any(endswith(source.url, ext) for ext in BinaryBuilderBase.archive_extensions)
+            "ArchiveSource($(url_string), $(repr(source.hash)))"
         else
-            "FileSource($(url_string), $(repr(x[2].hash)))"
+            "FileSource($(url_string), $(repr(source.hash)))"
         end
     end
     if !isempty(state.patches)

--- a/src/wizard/state.jl
+++ b/src/wizard/state.jl
@@ -31,7 +31,6 @@ necessary.  It also holds all necessary metadata such as input/output streams.
 
     # Filled in by step 2
     workspace::Union{Nothing, String} = nothing
-    source_urls::Union{Nothing, Vector{String}} = nothing
     source_files::Union{Nothing, Vector{SetupSource}} = nothing
     dependencies::Union{Nothing, Vector{Dependency}} = nothing
     compilers::Union{Nothing, Vector{Symbol}} = nothing

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -167,8 +167,7 @@ end
     state = Wizard.WizardState()
     state.step = :step34
     state.platforms = [Platform("x86_64", "linux")]
-    state.source_urls = ["http://127.0.0.1:14444/a/source.tar.gz"]
-    state.source_files = [BinaryBuilder.SetupSource{ArchiveSource}("/tmp/source.tar.gz", bytes2hex(sha256("a")), "")]
+    state.source_files = [BinaryBuilder.SetupSource{ArchiveSource}("http://127.0.0.1:14444/a/source.tar.gz", "/tmp/source.tar.gz", bytes2hex(sha256("a")), "")]
     state.name = "libfoo"
     state.version = v"1.0.0"
     state.dependencies = [Dependency(PackageSpec(;name="Zlib_jll")),

--- a/test/wizard.jl
+++ b/test/wizard.jl
@@ -178,7 +178,7 @@ end
         call_response(ins, outs, "Select the preferred LLVM version", "\e[B\e[B\e[B\r")
     end
     # Check that the state is modified appropriately
-    @test state.source_urls == ["http://127.0.0.1:$(port)/a/source.tar.gz"]
+    @test getfield.(state.source_files, :url) == ["http://127.0.0.1:$(port)/a/source.tar.gz"]
     @test getfield.(state.source_files, :hash) == [libfoo_tarball_hash]
     @test Set(state.compilers) == Set([:c, :rust, :go])
     @test state.preferred_gcc_version == getversion(available_gcc_builds[1])
@@ -201,7 +201,7 @@ end
         call_response(ins, outs, "Do you want to customize the set of compilers?", "N")
     end
     # Check that the state is modified appropriately
-    @test state.source_urls == [
+    @test getfield.(state.source_files, :url) == [
         "http://127.0.0.1:$(port)/a/source.tar.gz",
         "http://127.0.0.1:$(port)/b/source.tar.gz",
     ]
@@ -268,7 +268,7 @@ end
         call_response(ins, outs, "Enter a version number", "1.0.0")
         call_response(ins, outs, "Do you want to customize the set of compilers?", "N")
     end
-    @test state.source_urls == ["http://127.0.0.1:$(port)/a/source.tar.gz"]
+    @test getfield.(state.source_files, :url) == ["http://127.0.0.1:$(port)/a/source.tar.gz"]
     state = step2_state()   
     with_wizard_output(state, Wizard.step2) do ins, outs
         call_response(ins, outs, "Please enter a URL", "N")
@@ -295,8 +295,8 @@ function step3_state()
     state = Wizard.WizardState()
     state.step = :step34
     state.platforms = [Platform("x86_64", "linux")]
-    state.source_urls = ["http://127.0.0.1:$(port)/a/source.tar.gz"]
-    state.source_files = [BinaryBuilder.SetupSource{ArchiveSource}(libfoo_tarball_path, libfoo_tarball_hash, "")]
+    state.source_files = [BinaryBuilder.SetupSource{ArchiveSource}("http://127.0.0.1:$(port)/a/source.tar.gz",
+        libfoo_tarball_path, libfoo_tarball_hash, "")]
     state.name = "libfoo"
     state.version = v"1.0.0"
     state.dependencies = Dependency[]


### PR DESCRIPTION
Goes with https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/322. Part of the problem with the current setup is that the WizardState doesn't actually round trip properly, because the cache for archive downloads gets deleted. It could be reconstituted from source_urls of course, but it would be cleaner to just do that on-demand with the SetupSource (though this commit doesn't do that yet).