### PR TITLE
docs: add version bound for Documenter

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 BinaryBuilderBase = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0.27"


### PR DESCRIPTION
Hopefully a simple way to get the docs builds fixed (e.g. https://github.com/JuliaPackaging/BinaryBuilder.jl/actions/runs/6266351818/job/17017134146?pr=1295)

At some point it would be good to get the docs upgraded to 1.0, but this is a quick stop-gap.