### PR TITLE
Don't query GitHub username and use dummy credentials when committing

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1581,13 +1581,12 @@ end
 function push_jll_package(name, build_version;
                           code_dir = joinpath(Pkg.devdir(), "$(name)_jll"),
                           deploy_repo = "JuliaBinaryWrappers/$(name)_jll.jl",
-                          gh_auth = Wizard.github_auth(;allow_anonymous=false),
-                          gh_username = gh_get_json(DEFAULT_API, "/user"; auth=gh_auth)["login"])
+                          gh_auth = Wizard.github_auth(;allow_anonymous=false))
     # Next, push up the wrapper code repository
     wrapper_repo = LibGit2.GitRepo(code_dir)
     LibGit2.add!(wrapper_repo, ".")
     commit = LibGit2.commit(wrapper_repo, "$(name)_jll build $(build_version)")
-    Wizard.with_gitcreds(gh_username, gh_auth.token) do creds
+    Wizard.with_gitcreds("x-access-token", gh_auth.token) do creds
         refspecs = ["refs/heads/main"]
         # Fetch the remote repository, to have the relevant refspecs up to date.
         LibGit2.fetch(

--- a/src/wizard/deploy.jl
+++ b/src/wizard/deploy.jl
@@ -147,8 +147,7 @@ end
 function yggdrasil_deploy(name, version, patches, build_tarballs_content;
                           open_pr::Bool=false,
                           branch_name=nothing,
-                          gh_auth = github_auth(;allow_anonymous=false),
-                          gh_username=gh_get_json(DEFAULT_API, "/user"; auth=gh_auth)["login"])
+                          gh_auth = github_auth(;allow_anonymous=false))
     # First, fork Yggdrasil (this just does nothing if it already exists)
     fork = GitHub.create_fork("JuliaPackaging/Yggdrasil"; auth=gh_auth)
 
@@ -188,7 +187,7 @@ function yggdrasil_deploy(name, version, patches, build_tarballs_content;
         @info("Committing and pushing to $(fork.full_name)#$(branch_name)...")
         LibGit2.add!(repo, rel_bt_path)
         LibGit2.commit(repo, "New Recipe: $(name) v$(version)")
-        with_gitcreds(gh_username, gh_auth.token) do creds
+        with_gitcreds("x-access-token", gh_auth.token) do creds
             LibGit2.push(
                 repo,
                 refspecs=["+HEAD:refs/heads/$(branch_name)"],


### PR DESCRIPTION
This is a followup to https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1304 since there were two more authentications that relied on querying the potentially non-existent GitHub username. 

The second commit might not be the right approach but it allowed me to build new binaries while authenticating as a GitHub app. The issue is that https://github.com/JuliaPackaging/BinaryBuilder.jl/blob/ad70f55fb09aeb13324e4e69bf2c6df4b4e2fc4c/src/AutoBuild.jl#L1589 ends up querying username information from the local git repo when calling https://github.com/JuliaLang/julia/blob/187e8c2222878c68b2afc9295ab8dc61773bd7f2/stdlib/LibGit2/src/signature.jl#L66-L72. 