### PR TITLE
Allow building `PlatformSupport-*` Yggdrasil images again

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -187,7 +187,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         return nothing
     end
 
-    if !Base.isidentifier(src_name)
+    if !(Base.isidentifier(src_name) || startswith(src_name, "PlatformSupport-"))
         error("Package name \"$(src_name)\" is not a valid identifier")
     end
 


### PR DESCRIPTION
Disable a test that disallows the name `PlatformSupport-*`, which prevents us from updating the `PlatformSupport` Yggdrasil images.