### PR TITLE
Check for a branded ELF note when OS/ABI is NONE

### DIFF
--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -2,7 +2,7 @@ using ObjectFile.ELF
 
 function os_from_elf_note(oh::ELFHandle)
     for section in Sections(oh)
-        section_handle(section) == ELF.SHT_NOTE || continue
+        section_type(section) == ELF.SHT_NOTE || continue
         seek(oh, section_offset(section))
         name_length = read(oh, UInt32)
         iszero(name_length) && continue

--- a/src/auditor/dynamic_linkage.jl
+++ b/src/auditor/dynamic_linkage.jl
@@ -1,5 +1,30 @@
 using ObjectFile.ELF
 
+function os_from_elf_note(oh::ELFHandle)
+    for section in Sections(oh)
+        section_handle(section) == ELF.SHT_NOTE || continue
+        seek(oh, section_offset(section))
+        name_length = read(oh, UInt32)
+        iszero(name_length) && continue
+        descriptor_length = read(oh, UInt32)
+        note_type = read(oh, UInt32)
+        name = String(read(oh, name_length - 1))  # skip trailing NUL
+        if note_type == 1
+            # Technically it's part of the Linux specification that any executable should
+            # have an ELF note with type 1, name GNU, and descriptor length ≥4, but in
+            # practice I haven't observed that consistently, especially on musl. So for
+            # now, only bother checking FreeBSD, which uses an ELF note rather than OS/ABI
+            # to identify itself on AArch64 and RISC-V.
+            if name == "FreeBSD" && descriptor_length == 4
+                return name
+            end
+        end
+    end
+    return nothing
+end
+
+os_from_elf_note(::ObjectHandle) = nothing
+
 """
     platform_for_object(oh::ObjectHandle)
 
@@ -39,7 +64,9 @@ function platform_for_object(oh::ObjectHandle)
             end
         end
 
-        if oh.ei.osabi == ELF.ELFOSABI_LINUX || oh.ei.osabi == ELF.ELFOSABI_NONE
+        if oh.ei.osabi == ELF.ELFOSABI_NONE
+            return Platform(arch, os_from_elf_note(oh) == "FreeBSD" ? "freebsd" : "linux")
+        elseif oh.ei.osabi == ELF.ELFOSABI_LINUX
             return Platform(arch, "linux")
         elseif oh.ei.osabi == ELF.ELFOSABI_FREEBSD
             return Platform(arch, "freebsd")
@@ -107,6 +134,13 @@ function is_for_platform(h::ObjectHandle, platform::AbstractPlatform)
                 end
             else
                 error("Unknown OS ABI type $(typeof(platform))")
+            end
+        else
+            # If no OSABI, check whether it has a matching ELF note
+            if Sys.isfreebsd(platform)
+                if os_from_elf_note(h) != "FreeBSD"
+                    return false
+                end
             end
         end
         # Check that the ELF arch matches our own

--- a/src/auditor/extra_checks.jl
+++ b/src/auditor/extra_checks.jl
@@ -8,7 +8,7 @@ function check_os_abi(oh::ObjectHandle, p::AbstractPlatform, rest...; verbose::B
         # On AArch64 and RISC-V, FreeBSD uses an ELF note section to identify itself rather
         # than OS/ABI in the ELF header. In that case, the OS/ABI will be generic Unix (NONE).
         # See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=252490 and
-        # https://github.com/freebsd/freebsd-src/blob/main/lib/csu/common/crtbrand.S
+        # https://github.com/freebsd/freebsd-src/blob/d3c4b002d1fd54ac69c1714e208051867ee56dc4/lib/csu/common/crtbrand.S
         if oh.ei.osabi == ELF.ELFOSABI_NONE
             if os_from_elf_note(oh) != "FreeBSD"
                 if verbose

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -862,8 +862,8 @@ end
                     echo 'int right() { return 0; }' | cc -shared -fPIC -o "${libdir}/libright.${dlext}" -x c -
                     # NetBSD runs anywhere, which implies that anything that runs is for NetBSD, right?
                     elfedit --output-osabi=NetBSD "${libdir}/libwrong.${dlext}"
+                    strip --remove-section=.note.tag "${libdir}/libwrong.${dlext}"
                     """,
-                    # Build for Linux armv7l hard-float
                     [platform],
                     # Ensure our library product is built
                     [
@@ -886,11 +886,13 @@ end
             testdir = joinpath(build_path, "testdir")
             mkdir(testdir)
             unpack(tarball_path, testdir)
-            readmeta(joinpath(testdir, "lib", "libright.so")) do oh
+            readmeta(joinpath(testdir, "lib", "libright.so")) do ohs
+                oh = only(ohs)
                 @test is_for_platform(oh, platform)
                 @test check_os_abi(oh, platform)
             end
-            readmeta(joinpath(testdir, "lib", "libwrong.so")) do oh
+            readmeta(joinpath(testdir, "lib", "libwrong.so")) do ohs
+                oh = only(ohs)
                 @test !is_for_platform(oh, platform)
                 @test !check_os_abi(oh, platform)
             end

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -862,6 +862,8 @@ end
                     echo 'int wrong() { return 0; }' | cc -shared -fPIC -o "libwrong.${dlext}" -x c -
                     echo 'int right() { return 0; }' | cc -shared -fPIC -o "libright.${dlext}" -x c -
                     cp "libwrong.${dlext}" "libnonote.${dlext}"
+                    # We only check for a branded ELF note when the OS/ABI is 0
+                    elfedit --output-osabi=none "libnonote.${dlext}"
                     strip --remove-section=.note.tag "libnonote.${dlext}"
                     mv "libwrong.${dlext}" "libbadosabi.${dlext}"
                     # NetBSD runs anywhere, which implies that anything that runs is for NetBSD, right?

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -855,11 +855,13 @@ end
                     FileSource[],
                     # Build a library with a mismatched OS/ABI in the ELF header
                     raw"""
+                    apk update
+                    apk add binutils
                     mkdir -p "${libdir}"
                     echo 'int wrong() { return 0; }' | cc -shared -fPIC -o "${libdir}/libwrong.${dlext}" -x c -
                     echo 'int right() { return 0; }' | cc -shared -fPIC -o "${libdir}/libright.${dlext}" -x c -
                     # NetBSD runs anywhere, which implies that anything that runs is for NetBSD, right?
-                    patchelf --set-os-abi 2 "${libdir}/libwrong.${dlext}"
+                    elfedit --output-osabi=NetBSD "${libdir}/libwrong.${dlext}"
                     """,
                     # Build for Linux armv7l hard-float
                     [platform],

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -1,5 +1,6 @@
 using BinaryBuilder.Auditor
-using BinaryBuilder.Auditor: compatible_marchs, valid_library_path
+using BinaryBuilder.Auditor: check_os_abi, compatible_marchs, is_for_platform, valid_library_path
+using ObjectFile
 
 # Tests for our auditing infrastructure
 


### PR DESCRIPTION
Currently the auditor is only checking for the correct OS/ABI and producing a warning on FreeBSD when it doesn't match. This warning is incorrect on AArch64 though, as FreeBSD instead uses an ELF note to declare the OS/ABI. The change implemented here looks for such a note when the OS/ABI in the ELF header is NONE.

~~Note that there are no tests added... I'd be interested in any suggestions for how best to test this given that the functions I modified are not currently tested, at least directly (AFAICT).~~