### PR TITLE
Make pkg-config files relocatable post-installation

### DIFF
--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -344,14 +344,7 @@ end
                     v"1.0.0",
                     # Copy in the libfoo sources
                     [DirectorySource(build_tests_dir)],
-                    # Build libfoo using autotools to create a real .la file, and also
-                    # create a fake .la file (which should not be removed).  Create also a
-                    # symlink libqux.la -> libfoo.la, which will be broken after libfoo.la
-                    # has been deleted: remove libqux.la as well
-                    libfoo_autotools_script * raw"""
-                    touch ${prefix}/lib/libbar.la
-                    ln -s ${prefix}/lib/libfoo.la ${prefix}/lib/libqux.la
-                    """,
+                    libfoo_autotools_script,
                     # Build for our platform
                     [platform],
                     # The products we expect to be build

--- a/test/build_tests/libfoo/CMakeLists.txt
+++ b/test/build_tests/libfoo/CMakeLists.txt
@@ -15,6 +15,7 @@ elseif (UNIX)
     set_target_properties(fooifier PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
+install(FILES libfoo.pc DESTINATION lib/pkgconfig)
 install(TARGETS foo DESTINATION lib)
 install(TARGETS fooFramework DESTINATION lib)
 install(TARGETS fooifier RUNTIME DESTINATION bin)

--- a/test/build_tests/libfoo/Makefile.am
+++ b/test/build_tests/libfoo/Makefile.am
@@ -1,5 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libfoo.pc
+
 lib_LTLIBRARIES = libfoo.la
 libfoo_la_SOURCES = libfoo.c
 libfoo_la_LDFLAGS = -no-undefined

--- a/test/build_tests/libfoo/libfoo.pc
+++ b/test/build_tests/libfoo/libfoo.pc
@@ -1,0 +1,10 @@
+prefix=/workplace/destdir
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: Libfoo
+Description: Foo library, now without bar!
+Version: 1.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lfoo

--- a/test/build_tests/libfoo/meson.build
+++ b/test/build_tests/libfoo/meson.build
@@ -16,3 +16,5 @@ endif
 executable('fooifier', 'fooifier.cpp',
 	   link_with : libfoo, install : true,
 	   install_rpath : rpath_dir)
+
+install_data('libfoo.pc', install_dir: get_option('libdir')/'pkgconfig')


### PR DESCRIPTION
Solves #1338, but I haven't tested this.

Ping @giordano.