### PR TITLE
Allow building PlatformSupport packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilder"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -191,7 +191,7 @@ function build_tarballs(ARGS, src_name, src_version, sources, script,
         return nothing
     end
 
-    if validate_name && !Base.isidentifier(src_name)
+    if validate_name && !Base.isidentifier(src_name) && !startswith(src_name, "PlatformSupport-")
         error("Package name \"$(src_name)\" is not a valid identifier")
     end
 


### PR DESCRIPTION
This PR enables building PlatformSupport packages. Without this change, BinaryBuilder aborts with the respective error.