### PR TITLE
[AutoBuild] Always require JLLWrappers v1.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilder"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -7,7 +7,7 @@ import LibGit2
 import PkgLicenses
 
 const DEFAULT_JULIA_VERSION_SPEC = "1.0"
-const DEFAULT_JLLWRAPPERS_VERSION_SPEC = "1.2.0"
+const DEFAULT_JLLWRAPPERS_VERSION_SPEC = "1.7.0"
 const PKG_VERSIONS = Base.VERSION >= v"1.7-" ? Pkg.Versions : Pkg.Types
 
 mutable struct BuildTimer
@@ -597,7 +597,7 @@ function register_jll(name, build_version, dependencies, julia_compat;
     cache = RegistryTools.RegistryCache(joinpath(Pkg.depots1(), "registries_binarybuilder"))
     registry_url = "https://$(gh_username):$(gh_auth.token)@github.com/JuliaRegistries/General"
     cache.registries[registry_url] = Base.UUID("23338594-aafe-5451-b93e-139f81909106")
-    jllwrappers_compat = isempty(augment_platform_block) ? DEFAULT_JLLWRAPPERS_VERSION_SPEC : "1.4.0"
+    jllwrappers_compat = DEFAULT_JLLWRAPPERS_VERSION_SPEC
     project = Pkg.Types.Project(build_project_dict(name, build_version, dependencies, julia_compat; jllwrappers_compat, lazy_artifacts, augment_platform_block))
     project_file = joinpath(mktempdir(), "Project.toml")
     Pkg.Types.write_project(project, project_file)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -199,7 +199,7 @@ end
     @test dict["name"] == "$(name)_jll"
     @test dict["version"] == "1.0.0"
     @test dict["uuid"] == "8fcd9439-76b0-55f4-a525-bad0597c05d8"
-    @test dict["compat"] == Dict{String,Any}("julia" => "1.0", "JLLWrappers" => "1.2.0", "Pkg" => "< 0.0.1, 1", "Libdl" => "< 0.0.1, 1", "Artifacts" => "< 0.0.1, 1")
+    @test dict["compat"] == Dict{String,Any}("julia" => "1.0", "JLLWrappers" => "1.7.0", "Pkg" => "< 0.0.1, 1", "Libdl" => "< 0.0.1, 1", "Artifacts" => "< 0.0.1, 1")
     @test all(in.(
         (
             "Pkg"       => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
@@ -224,10 +224,10 @@ end
 
     # Ensure passing a Julia dependency bound works
     dict = build_project_dict(name, version, dependencies, "1.4")
-    @test dict["compat"] == Dict{String,Any}("julia" => "1.4", "JLLWrappers" => "1.2.0", "Pkg" => "< 0.0.1, 1", "Libdl" => "< 0.0.1, 1", "Artifacts" => "< 0.0.1, 1")
+    @test dict["compat"] == Dict{String,Any}("julia" => "1.4", "JLLWrappers" => "1.7.0", "Pkg" => "< 0.0.1, 1", "Libdl" => "< 0.0.1, 1", "Artifacts" => "< 0.0.1, 1")
 
     dict = build_project_dict(name, version, dependencies, "~1.4")
-    @test dict["compat"] == Dict{String,Any}("julia" => "~1.4", "JLLWrappers" => "1.2.0", "Pkg" => "< 0.0.1, 1", "Libdl" => "< 0.0.1, 1", "Artifacts" => "< 0.0.1, 1")
+    @test dict["compat"] == Dict{String,Any}("julia" => "~1.4", "JLLWrappers" => "1.7.0", "Pkg" => "< 0.0.1, 1", "Libdl" => "< 0.0.1, 1", "Artifacts" => "< 0.0.1, 1")
 
     @test_throws ErrorException build_project_dict(name, version, dependencies, "nonsense")
 

--- a/test/building.jl
+++ b/test/building.jl
@@ -114,14 +114,17 @@ shards_to_test = expand_cxxstring_abis(expand_gfortran_versions(shards_to_test))
             ]
 
             if !(platforms_match(shard, Platform("i686", "windows")) ||
-                 platforms_match(shard, Platform("aarch64", "freebsd")))
-                # Rust is broken on 32-bit Windows and unavailable on FreeBSD AArch64, let's skip it
+                 platforms_match(shard, Platform("aarch64", "freebsd")) ||
+                 platforms_match(shard, Platform("riscv64", "linux")))
+                # Rust is broken on 32-bit Windows and unavailable on FreeBSD AArch64 and RISC-V, let's skip it
                 push!(products, ExecutableProduct("hello_world_rust", :hello_world_rust))
             end
 
             compilers = [:c, :go]
-            # Don't even ask for Rust on FreeBSD AArch64
-            if !platforms_match(shard, Platform("aarch64", "freebsd"))
+            # Don't even ask for Rust on FreeBSD AArch64 or RISC-V
+            if !(platforms_match(shard, Platform("aarch64", "freebsd")) ||
+                 platforms_match(shard, Platform("riscv64", "linux"))
+                 )
                 push!(compilers, :rust)
             end
 

--- a/test/building.jl
+++ b/test/building.jl
@@ -140,8 +140,17 @@ shards_to_test = expand_cxxstring_abis(expand_gfortran_versions(shards_to_test))
                 if [[ "${target}" == i686-*-mingw* ]]; then
                     while which rustc &> /dev/null; do rm $(which rustc); done
                 fi
+
+                FLAGS=()
+                if [[ "${target}" == riscv*-linux-* ]]; then
+                    # There's currently a bug in the testsuite where we force linking to
+                    # libquadmath on RISC-V. We use this hack to quickly fix it here without
+                    # rebuilding the RootFS.
+                    FLAGS=(CFLDFLAGS="-lgfortran -lm")
+                fi
+
                 # Build testsuite
-                make -j${nproc} -sC /usr/share/testsuite install
+                make -j${nproc} -sC /usr/share/testsuite install "${FLAGS[@]}"
                 # Install fake license just to silence the warning
                 install_license /usr/share/licenses/libuv/LICENSE
                 """,

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -28,7 +28,7 @@ module TestJLL end
     @test project["compat"] == Dict(
         "julia" => "1.0",
         "XZ_jll" => "=2.4.6",
-        "JLLWrappers" => "1.2.0",
+        "JLLWrappers" => "1.7.0",
         "Libdl" => "< 0.0.1, 1",
         "Artifacts" => "< 0.0.1, 1",
         "Pkg" => "< 0.0.1, 1",


### PR DESCRIPTION
This is necessary to include https://github.com/JuliaPackaging/JLLWrappers.jl/pull/74, which allows loading JLL packages with unknown platforms.

This will be mildly disruptive because compat bounds will change and CI checks in the General registry won't like them, I suggest we resolve conflicts in the General registry (users installing such packages will likely upgrade to JLLWrappers v1.7 anyway).  I considered the option of changing the compat bound only if `riscv64` is among the architectures of the platforms in the new build, but

* the list of platforms isn't currently passed to `register_jll`, we could change that, but it's a a bit of a churn
* doing that wouldn't even be sufficient to avoid all issues in the registry, as we'll still likely publish new builds for many packages for the `riscv64` architecture, without changing the x.y.z version numbers, so that a good amount of work in the General registry will be necessary in any case