### PR TITLE
Pass through the new Rust and Go version arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinaryBuilder"
 uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
@@ -33,7 +33,7 @@ ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
 ArgParse = "1.1"
-BinaryBuilderBase = "1.33"
+BinaryBuilderBase = "1.34"
 Downloads = "1"
 GitHub = "5.1"
 HTTP = "0.8, 0.9, 1"

--- a/docs/src/build_tips.md
+++ b/docs/src/build_tips.md
@@ -95,7 +95,7 @@ Examples of builds performed with Meson include:
 
 ## Go builds
 
-The Go toolchain provided by BinaryBuilder can be requested by adding `:go` to the `compilers` keyword argument to [`build_tarballs`](@ref): `compilers=[:c, :go]`.  Go-based packages can usually be built and installed with `go`:
+The Go toolchain provided by BinaryBuilder can be requested by adding `:go` to the `compilers` keyword argument to [`build_tarballs`](@ref): `compilers=[:c, :go]`, and a specific version of the toolchain can be selected by adding the `preferred_go_version` keyword argument to [`build_tarballs`](@ref).  Go-based packages can usually be built and installed with `go`:
 
 ```sh
 go build -o ${bindir}
@@ -109,7 +109,7 @@ Example of packages using Go:
 
 ## Rust builds
 
-The Rust toolchain provided by BinaryBuilder can be requested by adding `:rust` to the `compilers` keyword argument to [`build_tarballs`](@ref): `compilers=[:c, :rust]`.  Rust-based packages can usually be built with `cargo`:
+The Rust toolchain provided by BinaryBuilder can be requested by adding `:rust` to the `compilers` keyword argument to [`build_tarballs`](@ref): `compilers=[:c, :rust]`, and a specific version of the toolchain can be selected by adding the `preferred_rust_version` keyword argument to [`build_tarballs`](@ref).  Rust-based packages can usually be built with `cargo`:
 
 ```sh
 cargo build --release
@@ -212,7 +212,7 @@ If in your build you need to use a package to a BLAS/LAPACK library you have the
 * always use LP64 interface, also on 64-bit systems.
   This may be a simpler option if renamining the BLAS/LAPACK symbols is too cumbersome in your case.
   In terms of libraries to link to:
-  - also in this case you can link to `libblastrampoline`, however you _must_ make sure an LP64 BLAS/LAPACK library is backing `libblastrampoline`, otherwise all BLAS/LAPACK calls from the library will result in hard-to-debug segmentation faults, because in this case Julia does not provided a default backing LP64 BLAS/LAPACK library on 64-bit systems 
+  - also in this case you can link to `libblastrampoline`, however you _must_ make sure an LP64 BLAS/LAPACK library is backing `libblastrampoline`, otherwise all BLAS/LAPACK calls from the library will result in hard-to-debug segmentation faults, because in this case Julia does not provided a default backing LP64 BLAS/LAPACK library on 64-bit systems
   - alternatively, you can use builds of BLAS/LAPACK libraries which always use LP64 interface also on 64-bit platforms, like the package `OpenBLAS32_jll`.
 
 ## Dependencies for the target system vs host system

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -819,7 +819,7 @@ function autobuild(dir::AbstractString,
         build_path = joinpath(dir, "build", triplet(platform))
         mkpath(build_path)
 
-        shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:bootstrap_list,:compilers))...)
+        shards = choose_shards(platform; extract_kwargs(kwargs, (:preferred_gcc_version,:preferred_llvm_version,:preferred_rust_version,:preferred_go_version,:bootstrap_list,:compilers))...)
         concrete_platform = get_concrete_platform(platform, shards)
 
         prefix = setup_workspace(


### PR DESCRIPTION
Companion PR to https://github.com/JuliaPackaging/BinaryBuilderBase.jl/pull/399 to allow passing the keyword arguments through to the underlying shard selector.