### PR TITLE
[AutoBuild] Replaced platform triplet string comparison with platform comparison in rebuild_jll_package

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1171,8 +1171,25 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
     build_output_meta = Dict()
 
     # For each platform, we have two tarballs: the main with the full product,
-    # and the logs-only one.  This function filters out the logs one.
-    filter_main_tarball(f, platform) = occursin(".$(triplet(platform)).tar", f) && !occursin("-logs.", f)
+    # and the logs-only one.  This function filters out the logs one, and
+    # finds the tarball matching `platform`.
+    function filter_main_tarball(tarball_filename, platform)
+        if occursin("-logs.", tarball_filename)
+            return false
+        end
+        tarball_filename_match = match(r"^(?<name>[\w_]+)\.v(?<version>\d+\.\d+\.\d+)\.(?<platform_triplet>([^-]+-?)+).tar", tarball_filename)
+        if isnothing(tarball_filename_match)
+            @warn "Tarball filename does not match expected pattern: $(tarball_filename)"
+            return false
+        end
+        try
+            tarball_filename_platform = parse(Platform, tarball_filename_match[:platform_triplet])
+            return tarball_filename_platform == platform
+        catch
+            @warn "Failed to parse tarball filename: $(tarball_filename)"
+            return false
+        end
+    end
 
     # Then generate a JLL package for each platform
     downloaded_files = readdir(download_dir)

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -47,6 +47,8 @@ module TestJLL end
         @test !BinaryBuilder.filter_main_tarball("", AnyPlatform())
         @test BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
         @test !BinaryBuilder.filter_main_tarball("Foo-logs.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
+        @test !BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu-cxx11.tar.gz", Platform("x86_64", "linux"))
+        @test !BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"; cxxstring_abi="cxx11"))
         @test BinaryBuilder.filter_main_tarball("Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda+12.0-cuda_platform+jetson.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
         @test BinaryBuilder.filter_main_tarball("Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda_platform+jetson-cuda+12.0.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
     end

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -43,6 +43,14 @@ module TestJLL end
         @test !haskey(BinaryBuilder.build_project_dict("foo", v"1.2", Dependency[], "1.6")["deps"], "Pkg")
     end
 
+    @testset "filter_main_tarball" begin
+        @test !BinaryBuilder.filter_main_tarball("", AnyPlatform())
+        @test BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
+        @test !BinaryBuilder.filter_main_tarball("Foo-logs.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
+        @test BinaryBuilder.filter_main_tarball("Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda+12.0-cuda_platform+jetson.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
+        @test BinaryBuilder.filter_main_tarball("Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda_platform+jetson-cuda+12.0.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
+    end
+
     @testset "get_github_author_login" begin
         gh_auth = Wizard.github_auth(;allow_anonymous=true)
         @test get_github_author_login("JuliaPackaging/Yggdrasil", "invalid_hash"; gh_auth) === nothing

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -7,43 +7,49 @@ using BinaryBuilder: jll_uuid, build_project_dict, get_github_author_login, Wiza
 module TestJLL end
 
 @testset "JLLs - utils" begin
-    @test jll_uuid("Zlib_jll") == UUID("83775a58-1f1d-513f-b197-d71354ab007a")
-    @test jll_uuid("FFMPEG_jll") == UUID("b22a6f82-2f65-5046-a5b2-351ab43fb4e5")
+    @testset "jll_uuid" begin
+        @test jll_uuid("Zlib_jll") == UUID("83775a58-1f1d-513f-b197-d71354ab007a")
+        @test jll_uuid("FFMPEG_jll") == UUID("b22a6f82-2f65-5046-a5b2-351ab43fb4e5")
+    end
 
-    project = build_project_dict("LibFoo", v"1.3.5",
-        [Dependency("Zlib_jll"),
-         Dependency(PackageSpec(name = "XZ_jll"), compat = "=2.4.6"),
-         Dependency(PackageSpec(name = "Preferences", uuid = parse(UUID, "21216c6a-2e73-6563-6e65-726566657250"))),
-         Dependency("Scratch"),])
-    @test project["deps"] == Dict("JLLWrappers" => "692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
-                                  "Artifacts"   => "56f22d72-fd6d-98f1-02f0-08ddc0907c33",
-                                  "Pkg"         => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
-                                  "Zlib_jll"    => "83775a58-1f1d-513f-b197-d71354ab007a",
-                                  "Libdl"       => "8f399da3-3557-5675-b5ff-fb832c97cbdb",
-                                  "XZ_jll"      => "ffd25f8a-64ca-5728-b0f7-c24cf3aae800",
-                                  "Preferences" => "21216c6a-2e73-6563-6e65-726566657250",
-                                  "Scratch"     => "6c6a2e73-6563-6170-7368-637461726353")
-    @test project["name"] == "LibFoo_jll"
-    @test project["uuid"] == "b250f842-3251-58d3-8ee4-9a24ab2bab3f"
-    @test project["compat"] == Dict(
-        "julia" => "1.0",
-        "XZ_jll" => "=2.4.6",
-        "JLLWrappers" => "1.7.0",
-        "Libdl" => "< 0.0.1, 1",
-        "Artifacts" => "< 0.0.1, 1",
-        "Pkg" => "< 0.0.1, 1",
-    )
-    @test project["version"] == "1.3.5"
-    # Make sure BuildDependency's don't find their way to the project
-    @test_throws AssertionError build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), BuildDependency("Xorg_util_macros_jll")])
-    # `Pkg` should not be a dependency if we require Julia v1.6.
-    @test !haskey(BinaryBuilder.build_project_dict("foo", v"1.2", Dependency[], "1.6")["deps"], "Pkg")
+    @testset "build_project_dict" begin
+        project = build_project_dict("LibFoo", v"1.3.5",
+            [Dependency("Zlib_jll"),
+            Dependency(PackageSpec(name = "XZ_jll"), compat = "=2.4.6"),
+            Dependency(PackageSpec(name = "Preferences", uuid = parse(UUID, "21216c6a-2e73-6563-6e65-726566657250"))),
+            Dependency("Scratch"),])
+        @test project["deps"] == Dict("JLLWrappers" => "692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+                                    "Artifacts"   => "56f22d72-fd6d-98f1-02f0-08ddc0907c33",
+                                    "Pkg"         => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
+                                    "Zlib_jll"    => "83775a58-1f1d-513f-b197-d71354ab007a",
+                                    "Libdl"       => "8f399da3-3557-5675-b5ff-fb832c97cbdb",
+                                    "XZ_jll"      => "ffd25f8a-64ca-5728-b0f7-c24cf3aae800",
+                                    "Preferences" => "21216c6a-2e73-6563-6e65-726566657250",
+                                    "Scratch"     => "6c6a2e73-6563-6170-7368-637461726353")
+        @test project["name"] == "LibFoo_jll"
+        @test project["uuid"] == "b250f842-3251-58d3-8ee4-9a24ab2bab3f"
+        @test project["compat"] == Dict(
+            "julia" => "1.0",
+            "XZ_jll" => "=2.4.6",
+            "JLLWrappers" => "1.7.0",
+            "Libdl" => "< 0.0.1, 1",
+            "Artifacts" => "< 0.0.1, 1",
+            "Pkg" => "< 0.0.1, 1",
+        )
+        @test project["version"] == "1.3.5"
+        # Make sure BuildDependency's don't find their way to the project
+        @test_throws AssertionError build_project_dict("LibFoo", v"1.3.5", [Dependency("Zlib_jll"), BuildDependency("Xorg_util_macros_jll")])
+        # `Pkg` should not be a dependency if we require Julia v1.6.
+        @test !haskey(BinaryBuilder.build_project_dict("foo", v"1.2", Dependency[], "1.6")["deps"], "Pkg")
+    end
 
-    gh_auth = Wizard.github_auth(;allow_anonymous=true)
-    @test get_github_author_login("JuliaPackaging/Yggdrasil", "invalid_hash"; gh_auth) === nothing
-    @test get_github_author_login("JuliaPackaging/Yggdrasil", "815de56a4440f4e05333c5295d74f1dc9b73ebe3"; gh_auth) === nothing
-    if gh_auth != GitHub.AnonymousAuth()
-        @test get_github_author_login("JuliaPackaging/Yggdrasil", "dea7c3fadad16281ead2427f7ab9b32f1c8cb664"; gh_auth) === "Pangoraw"
+    @testset "get_github_author_login" begin
+        gh_auth = Wizard.github_auth(;allow_anonymous=true)
+        @test get_github_author_login("JuliaPackaging/Yggdrasil", "invalid_hash"; gh_auth) === nothing
+        @test get_github_author_login("JuliaPackaging/Yggdrasil", "815de56a4440f4e05333c5295d74f1dc9b73ebe3"; gh_auth) === nothing
+        if gh_auth != GitHub.AnonymousAuth()
+            @test get_github_author_login("JuliaPackaging/Yggdrasil", "dea7c3fadad16281ead2427f7ab9b32f1c8cb664"; gh_auth) === "Pangoraw"
+        end
     end
 end
 


### PR DESCRIPTION
Should remedy issues seen with registration of ONNXRuntime_CUDA (using the `cuda_platform` platform tag, e.g., `cuda_platform="jetson"`) in https://github.com/JuliaPackaging/Yggdrasil/pull/10426, and investigated in https://github.com/JuliaPackaging/Yggdrasil/pull/10476 .