### PR TITLE
Fix `filter_main_tarball`

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1168,7 +1168,7 @@ function filter_main_tarball(tarball_filename, platform)
     if occursin("-logs.", tarball_filename)
         return false
     end
-    tarball_filename_match = match(r"^(?<name>[\w_]+)\.v(?<version>\d+\.\d+\.\d+)\.(?<platform_triplet>([^-]+-?)+).tar", tarball_filename)
+    tarball_filename_match = match(r"^(.*/)?(?<name>[\w_]+)\.v(?<version>\d+\.\d+\.\d+)\.(?<platform_triplet>([^-]+-?)+).tar", tarball_filename)
     if isnothing(tarball_filename_match)
         @warn "Tarball filename does not match expected pattern: $(tarball_filename)"
         return false

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1174,6 +1174,9 @@ function filter_main_tarball(tarball_filename, platform)
         return false
     end
     try
+        if platform isa AnyPlatform
+            return tarball_filename_match[:platform_triplet] == "any"
+        end
         tarball_filename_platform = parse(Platform, tarball_filename_match[:platform_triplet])
         return tarball_filename_platform == platform
     catch

--- a/test/jll.jl
+++ b/test/jll.jl
@@ -45,12 +45,15 @@ module TestJLL end
 
     @testset "filter_main_tarball" begin
         @test !BinaryBuilder.filter_main_tarball("", AnyPlatform())
-        @test BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
-        @test !BinaryBuilder.filter_main_tarball("Foo-logs.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
-        @test !BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu-cxx11.tar.gz", Platform("x86_64", "linux"))
-        @test !BinaryBuilder.filter_main_tarball("Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"; cxxstring_abi="cxx11"))
-        @test BinaryBuilder.filter_main_tarball("Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda+12.0-cuda_platform+jetson.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
-        @test BinaryBuilder.filter_main_tarball("Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda_platform+jetson-cuda+12.0.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
+        @test BinaryBuilder.filter_main_tarball("F/Foo/products/Foo.v1.2.3.any.tar.gz", AnyPlatform())
+        @test BinaryBuilder.filter_main_tarball("F/Foo/products/Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
+        @test !BinaryBuilder.filter_main_tarball("F/Foo/products/Foo-logs.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
+        @test !BinaryBuilder.filter_main_tarball("F/Foo/products/Foo.v1.2.3.x86_64-linux-gnu-cxx11.tar.gz", Platform("x86_64", "linux"))
+        @test !BinaryBuilder.filter_main_tarball("F/Foo/products/Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"; cxxstring_abi="cxx11"))
+        @test BinaryBuilder.filter_main_tarball("F/Foo/products/Foo.v1.2.3.x86_64-linux-gnu-cxx11.tar.gz", Platform("x86_64", "linux"; cxxstring_abi="cxx11"))
+        @test BinaryBuilder.filter_main_tarball("F/Foo_Bar/products/Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda+12.0-cuda_platform+jetson.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
+        @test BinaryBuilder.filter_main_tarball("F/Foo_Bar/products/Foo_Bar.v1.2.3.aarch64-linux-gnu-cuda_platform+jetson-cuda+12.0.tar.gz", Platform("aarch64", "linux"; cuda="12.0", cuda_platform="jetson"))
+        @test BinaryBuilder.filter_main_tarball("F/Foo/Foo@1.2/products/Foo.v1.2.3.x86_64-linux-gnu.tar.gz", Platform("x86_64", "linux"))
     end
 
     @testset "get_github_author_login" begin


### PR DESCRIPTION
This should fix the issue encountered in https://github.com/JuliaPackaging/Yggdrasil/pull/10611#issuecomment-2681599438.

There were actually two issues that are fixed by this PR:
- `filter_main_tarball` gets a path and not a filename as the first arg.
- the triplet parsing fails for `any`

I don't think there is a way to test it apart from somehow getting this version into the yggdrasil toolchain and re-running CI on https://github.com/JuliaPackaging/Yggdrasil/commit/3751eecbc3120c92219aaf056bf8d1bf2511bc9c again. (Which would be great to have anyway to get the GAP_lib_jll release from there into the registry.)

cc @fingolfin @giordano 