### PR TITLE
Update build_tips.md

### DIFF
--- a/docs/src/build_tips.md
+++ b/docs/src/build_tips.md
@@ -127,6 +127,34 @@ Example of packages using Rust:
 
 	The Rust toolchain currently used does not work with the `i686-w64-mingw32` (32-bit Windows) platform.
 
+ ## C builds
+
+ If your library has no build system like Make, CMake, Meson, or Autoconf, you may need to use the C compiler directly.  The C compiler is stored in the `CC` environment variable, and you can direct output to `libdir` (shared libraries) and `bindir` (executables).
+
+ ```sh
+# this assumes you are operating out of a Git source named `hello`
+# adjust your `cd` appropriately
+cd $WORKSPACE/srcdir/hello 
+mkdir -p ${libdir}                                         # make sure the libdir is instantiated
+${CC} -shared -o ${libdir}/libhello.${dlext} -fPIC hello.c # compile the library, save to `libdir`
+```
+
+This is simply compiling a single shared library, `libhello`, from `hello.c`.
+
+## C++ builds
+
+Similarly to C builds, sometimes your C++ libraries will not have a build system associated with them.  The C++ compiler is stored in the `CXX` environment variable.
+
+```sh
+# this assumes you are operating out of a Git source named `hello`
+# adjust your `cd` appropriately
+cd $WORKSPACE/srcdir/hello
+mkdir -p ${libdir}
+$CXX -shared -std=c++11 -O3 -fPIC -o ${libdir}/libhello.${dlext} src/hello.cpp # you may want to edit the `std` flag, for exampLE
+```
+
+This is simply compiling a single shared library, `libhello`, from `hello.cpp`.
+
 ## Editing files in the wizard
 
 In the wizard, the `vim` editor is available for editing files. But, it doesn't leave any record in the build script. One generally needs to provide patch files or use something like `sed`. If a file needs patching, we suggest using `git` to add the entire worktree to a new repo, make the changes you need, then use `git diff -p` to output a patch that can be included alongside your build recipe.


### PR DESCRIPTION
Adds brief descriptions of how to do "bare" (no build system) C and C++ builds - just to show where things should go.