### PR TITLE
Remove `.pkg` if no longer augmenting

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1561,7 +1561,7 @@ function build_jll_package(src_name::String,
               """)
     else
         # If no augmentation exists, ensure that the pkg_dir get's removed again.
-        rm(pkg_dir, recursive=true), force=true
+        Base.rm(pkg_dir, recursive=true, force=true)
     end
 
     # Generate target-demuxing main source file.

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1560,7 +1560,7 @@ function build_jll_package(src_name::String,
               TOML.print(stdout, artifacts)
               """)
     else
-        # If no augmentation exists, ensure that the pkg_dir get's removed again.
+        # If no augmentation exists, ensure that the pkg_dir gets removed again.
         Base.rm(pkg_dir, recursive=true, force=true)
     end
 

--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1559,6 +1559,9 @@ function build_jll_package(src_name::String,
               # Output the result to `stdout` as a TOML dictionary
               TOML.print(stdout, artifacts)
               """)
+    else
+        # If no augmentation exists, ensure that the pkg_dir get's removed again.
+        rm(pkg_dir, recursive=true), force=true
     end
 
     # Generate target-demuxing main source file.


### PR DESCRIPTION
@maleadt removed augmentation recently from pocl_jll 

https://github.com/JuliaBinaryWrappers/pocl_jll.jl/commit/cfcdb23a62c76e835704c047753a0a69dae9e041

But the `.pkg` dir remained confusing things down the road.
