### PR TITLE
print some context info for privileges in test suite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,8 @@ make install
 install_license ${WORKSPACE}/srcdir/libfoo/LICENSE.md
 """
 
+BinaryBuilderBase.versioninfo()  # print some context for the current runner
+
 # Run all our tests
 include("basic.jl")
 include("building.jl")


### PR DESCRIPTION
I've had a look at https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/1377, and I couldn't easily find where the `sudo` prompt cmd was ran (it took me some time to find that it was defined in `BinaryBuilderBase`) and also the first tests using it in `basic.jl` are hiding valuable stdout/err output, so I thought it would be a good idea to print some information about preferred sunner and privileges as soon as possible in the test suite.


This is what the test suite output looks like after this PR:
```
     Testing Running tests...
[ Info: Julia versioninfo():
Julia Version 1.7.3
Commit 742b9abb4d (2022-05-06 12:58 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: 12th Gen Intel(R) Core(TM) i7-12700H
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, goldmont)
[ Info: BinaryBuilderBase.jl version: 1.37.0-tree-3aeceb80d8
[ Info: Kernel version: 6.11.0-29-generic
[ Info: pkg dir is NOT encrypted on mountpoint /
[ Info: storage dir is NOT encrypted on mountpoint /
[ Info: Relevant environment variables:
[ Info: Preferred runner: UserNSRunner
[ Info: Trying to run `echo hello julia` within a Linux x86_64 environment...
[ Info: Checking to see if [...]/BinaryBuilder.jl/test/ is encrypted...
[ Info: Checking to see if [...]/.julia/packages/BinaryBuilderBase/DhTtP/deps/ is encrypted...
┌ Warning: Unable to run unprivileged containers on this system! This may be because your kernel does not support mounting overlay filesystems within user namespaces. To work around this, we will switch to using privileged containers. This requires the use of sudo. To choose this automatically, set the BINARYBUILDER_RUNNER environment variable to "privileged" before starting Julia.
└ @ BinaryBuilderBase [...]/.julia/packages/BinaryBuilderBase/DhTtP/src/UserNSRunner.jl:97
[ Info: Running privileged container via `sudo`, may ask for your password:
[sudo] password for [...]:
```

, so it's now easy to have a look at `BinaryBuilderBase/src/UserNSRunner.jl:97`.

cc @giordano @eschnett