### PR TITLE
Fix error on ratelimit

### DIFF
--- a/src/wizard/github.jl
+++ b/src/wizard/github.jl
@@ -83,6 +83,7 @@ function obtain_token(; outs=stdout, github_api=GitHub.DEFAULT_API)
             elseif error_kind == "slow_down"
                 @warn "GitHub Auth rate limit exceeded. Waiting 10s. (This shouldn't happen)"
                 sleep(10)
+                continue
             elseif error_kind == "expired_token"
                 @error "Token request expired. Starting over!"
                 @goto retry


### PR DESCRIPTION
If we get a rate limit error there is no "access_token" key in the reply causing an error.