### PR TITLE
AutoBuild: Filter for `.tar` extension before checking tarball

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1209,6 +1209,9 @@ function filter_main_tarball(tarball_filename, platform)
     if occursin("-logs.", tarball_filename)
         return false
     end
+    if !occursin(r"\.tar(\.\w+)?$", tarball_filename)
+        return false
+    end
     tarball_filename_match = match(r"^(.*/)?(?<name>[\w_]+)\.v(?<version>\d+\.\d+\.\d+)\.(?<platform_triplet>([^-]+-?)+).tar", tarball_filename)
     if isnothing(tarball_filename_match)
         @warn "Tarball filename does not match expected pattern: $(tarball_filename)"


### PR DESCRIPTION
Resolves this unnecessary warning: https://buildkite.com/julialang/yggdrasil/builds/28868#019dbaef-0290-4cfa-8e5e-8e2235c9d8d0/L685-L686