### PR TITLE
Save download size in Artifacts.toml (Julia 1.13+)

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -1043,6 +1043,8 @@ function autobuild(dir::AbstractString,
             # Do not include logs into the main tarball
             filter=exclude_logs,
         )
+        tarball_size = filesize(tarball_path)
+        iszero(tarball_size) && error("tarball has zero filesize: $(repr(tarball_path))")
         # Create another tarball only for the logs
         package(
             dest_prefix,
@@ -1061,6 +1063,7 @@ function autobuild(dir::AbstractString,
             tarball_hash,
             git_hash,
             products_info,
+            tarball_size,
         )
 
         # Destroy the workspace, taking care to make sure that we don't run into any
@@ -1264,6 +1267,8 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
         tarball_hash = open(tarball_path, "r") do io
             bytes2hex(sha256(io))
         end
+        tarball_size = filesize(tarball_path)
+        iszero(tarball_size) && error("tarball has zero filesize: $(repr(tarball_path))")
 
         # Unpack the tarball into a new location, calculate the git hash and locate() each product;
         mktempdir() do dest_prefix
@@ -1296,6 +1301,7 @@ function rebuild_jll_package(name::String, build_version::VersionNumber, sources
                 tarball_hash,
                 git_hash,
                 products_info,
+                tarball_size,
             )
 
             # Override read-only permissions before cleaning-up the directory
@@ -1346,12 +1352,12 @@ function build_jll_package(src_name::String,
 
         # Extract this platform's information.  Each of these things can be platform-specific
         # (including the set of products!) so be general here.
-        tarball_name, tarball_hash, git_hash, products_info = build_output_meta[platform]
+        tarball_name, tarball_hash, git_hash, products_info, tarball_size = build_output_meta[platform]
 
         # Add an Artifacts.toml
         artifacts_toml = joinpath(code_dir, "Artifacts.toml")
         download_info = Tuple[
-            (joinpath(bin_path, basename(tarball_name)), tarball_hash),
+            (joinpath(bin_path, basename(tarball_name)), tarball_hash, tarball_size),
         ]
         if platform isa AnyPlatform
             # AnyPlatform begs for a platform-independent artifact

--- a/test/auditing.jl
+++ b/test/auditing.jl
@@ -82,6 +82,7 @@ end
             @test haskey(build_output_meta, platform)
             tarball_path, tarball_hash = build_output_meta[platform][1:2]
             @test isfile(tarball_path)
+            @test build_output_meta[platform][5] == filesize(tarball_path)
 
             # Unpack it somewhere else
             @test verify(tarball_path, tarball_hash)


### PR DESCRIPTION
In Julia 1.13+ Pkg can optionally save the artifact download size `Artifacts.toml`. Ref: https://github.com/JuliaPackaging/ArtifactUtils.jl/pull/25 https://github.com/JuliaLang/Pkg.jl/pull/4171

This value isn't used anywhere yet, but could be used by a future version of Pkg.