### PR TITLE
Fix call to registry_info() on 1.13

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -570,7 +570,11 @@ function get_next_wrapper_version(src_name::AbstractString, src_version::Version
                 continue
             end
 
-            pkg_info = Pkg.Registry.registry_info(reg[uuid])
+            pkg_info = if VERSION >= v"1.13-"
+                Pkg.Registry.registry_info(reg, reg[uuid])
+            else
+                Pkg.Registry.registry_info(reg[uuid])
+            end
             append!(versions, sort!(collect(keys(pkg_info.version_info))))
         end
         unique!(sort!(versions))


### PR DESCRIPTION
Without it I get this error on 1.13 nightly:
```julia
ERROR: LoadError: MethodError: no method matching registry_info(::Pkg.Registry.PkgEntry)                                                                                                                                                       
The function `registry_info` exists, but no method is defined for this combination of argument types.                                                                                                                                          
                                                                                                                                                                                                                                               
Closest candidates are:                                                                                                                                                                                                                        
  registry_info(::Pkg.Registry.RegistryInstance, ::Pkg.Registry.PkgEntry)                                                                                                                                                                      
   @ Pkg ~/.julia/juliaup/julia-1.13-nightly/share/julia/stdlib/v1.13/Pkg/src/Registry/registry_instance.jl:485                                                                                                                                
                                                                                                                                                                                                                                               
Stacktrace:                                                                                                                                                                                                                                    
 [1] get_next_wrapper_version(src_name::String, src_version::VersionNumber)                                                                                                                                                                    
   @ BinaryBuilder ~/.julia/packages/BinaryBuilder/YNHY8/src/AutoBuild.jl:560                                                                                                                                                                  
 [2] build_tarballs(ARGS::Any, src_name::Any, src_version::Any, sources::Any, script::Any, platforms::Any, products::Any, dependencies::Any; julia_compat::String, validate_name::Bool, compression_format::String, kwargs...)                 
   @ BinaryBuilder ~/.julia/packages/BinaryBuilder/YNHY8/src/AutoBuild.jl:319                                                                                                                                                                  
 [3] kwcall(::NamedTuple, ::typeof(build_tarballs), ARGS::Any, src_name::Any, src_version::Any, sources::Any, script::Any, platforms::Any, products::Any, dependencies::Any)                                                                   
   @ BinaryBuilder ~/.julia/packages/BinaryBuilder/YNHY8/src/AutoBuild.jl:189
 [4] top-level scope
   @ ~/git/Yggdrasil/C/CImGuiPack/build_tarballs.jl:79
 [5] include(mod::Module, _path::String)
   @ Base ./Base.jl:309
 [6] exec_options(opts::Base.JLOptions)
   @ Base ./client.jl:344
 [7] _start()
   @ Base ./client.jl:577
```

I think this would've been caught by CI, but if I read `azure-pipelines.yml` right it looks like the tests only run on 1.7?