### PR TITLE
Write the compat of RuntimeDependency into the JLL Project.toml

### DIFF
--- a/src/AutoBuild.jl
+++ b/src/AutoBuild.jl
@@ -2125,7 +2125,7 @@ function build_project_dict(name, version, dependencies::Array{<:AbstractDepende
             uuid = jll_uuid(depname)
         end
         project["deps"][depname] = string(uuid)
-        if dep isa Dependency && length(dep.compat) > 0
+        if dep isa Union{Dependency,RuntimeDependency} && length(dep.compat) > 0
             Pkg.Types.semver_spec(dep.compat) # verify dep.compat is valid
             project["compat"][depname] = dep.compat
         end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -216,6 +216,12 @@ end
     # Make sure that a `BuildDependency` can't make it to the list of
     # dependencies of the new JLL package
     @test_throws AssertionError build_project_dict(name, version, [BuildDependency("Foo_jll")])
+    # The compat of both `Dependency` and `RuntimeDependency` ends up in the project
+    dict = build_project_dict(name, version, [Dependency("GMP_jll"; compat="6.2"),
+                                              RuntimeDependency("Zlib_jll"; compat="1.2.13")])
+    @test dict["compat"]["GMP_jll"] == "6.2"
+    @test dict["compat"]["Zlib_jll"] == "1.2.13"
+    @test haskey(dict["deps"], "Zlib_jll")
 
     version = v"1.6.8"
     next_version = BinaryBuilder.get_next_wrapper_version("Xorg_libX11", version)

--- a/test/building.jl
+++ b/test/building.jl
@@ -10,21 +10,24 @@ using BinaryBuilderBase: detect_compressor
             mkpath(git_path)
 
             # Copy files in, commit them.  This is the commit we will build.
+            # Sign the commits explicitly so that the test does not depend on the git
+            # identity configured on the machine running it.
             repo = LibGit2.init(git_path)
-            LibGit2.commit(repo, "Initial empty commit")
+            signature = LibGit2.Signature("BinaryBuilder tests", "test@example.com")
+            LibGit2.commit(repo, "Initial empty commit"; author=signature, committer=signature)
             libfoo_src_dir = joinpath(build_tests_dir, "libfoo")
             run(`cp -r $(libfoo_src_dir)/$(readdir(libfoo_src_dir)) $(git_path)/`)
             for file in readdir(git_path)
                 LibGit2.add!(repo, file)
             end
-            commit = LibGit2.commit(repo, "Add libfoo files")
+            commit = LibGit2.commit(repo, "Add libfoo files"; author=signature, committer=signature)
 
             # Add another commit to ensure that the git checkout is getting the right commit.
             open(joinpath(git_path, "Makefile"), "w") do io
                 println(io, "THIS WILL BREAK EVERYTHING")
             end
             LibGit2.add!(repo, "Makefile")
-            LibGit2.commit(repo, "Break Makefile")
+            LibGit2.commit(repo, "Break Makefile"; author=signature, committer=signature)
 
             for source in (DirectorySource(build_tests_dir),
                            GitSource(git_path, bytes2hex(LibGit2.raw(LibGit2.GitHash(commit)))))


### PR DESCRIPTION
`RuntimeDependency` accepts a `compat` keyword (validated in its constructor and documented as "for use in the Project.toml of the generated Julia package"), but `build_project_dict` only copied the compat of `Dependency` into the generated `[compat]` section, so a run-time-only dependency ended up unbounded in the JLL's Project.toml. Add a test covering both dependency kinds.

Fixes #1330.